### PR TITLE
deal with partial img tags

### DIFF
--- a/functions/strings/strip_tags.js
+++ b/functions/strings/strip_tags.js
@@ -36,10 +36,11 @@ function strip_tags(input, allowed) {
     .toLowerCase()
     .match(/<[a-z][a-z0-9]*>/g) || [])
     .join(''); // making sure the allowed arg is a string containing only tags in lowercase (<a><b><c>)
-  var tags = /<\/?([a-z][a-z0-9]*)\b[^>]*>/gi,
+  var tags = /<\/?([a-z][a-z0-9]*)\b[^>]*>|<(img)\b[^>]*/gi,
     commentsAndPhpTags = /<!--[\s\S]*?-->|<\?(?:php)?[\s\S]*?\?>/gi;
   return input.replace(commentsAndPhpTags, '')
-    .replace(tags, function ($0, $1) {
+    .replace(tags, function ($0, $1, $2) {
+      $1 = $1 || $2;
       return allowed.indexOf('<' + $1.toLowerCase() + '>') > -1 ? $0 : '';
     });
 }


### PR DESCRIPTION
Some browsers will tolerate img tags without a closing '>', ex. <img src="http://image.src.com"
This would not be stripped by the current implementation and would create an img tag in some browsers.