### PR TITLE
Update base64_encode.js

### DIFF
--- a/functions/url/base64_encode.js
+++ b/functions/url/base64_encode.js
@@ -13,39 +13,28 @@ function base64_encode(data) {
   //   returns 2: 'YQ=='
   //   example 3: base64_encode('✓ à la mode');
   //   returns 3: '4pyTIMOgIGxhIG1vZGU='
-
-  var b64 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
-  var o1, o2, o3, h1, h2, h3, h4, bits, i = 0,
-    ac = 0,
-    enc = '',
-    tmp_arr = [];
-
-  if (!data) {
-    return data;
-  }
-
+  // Wheel re-invented by Warren Gardner (http://www.madmessaging.co.za)
+  
+  if(!data) return data;
   data = unescape(encodeURIComponent(data));
+  
+  var cArray = new Uint8Array(data);
+  var DataLen = cArray.length, Out = "", Mask = 0xFC, Shift = 6, Carry = 0, i = 0;
+  
+  while(i < DataLen){
+      Out += b64[(Carry << Shift) | ((Mask & cArray[i]) >> (8 - Shift))];
+      if(!Shift){  
+          Mask = 0xFC;
+          Shift = 6;
+          Carry = 0;
+      }else{
+          Carry = ((~Mask) & cArray[i]);
+          Shift -= 2;
+          Mask = (Mask << 2) & 0xFF;
+      }
+      if(Shift) i++;
+   }
+  if(Carry) Out += b64[(Carry << Shift)];
 
-  do {
-    // pack three octets into four hexets
-    o1 = data.charCodeAt(i++);
-    o2 = data.charCodeAt(i++);
-    o3 = data.charCodeAt(i++);
-
-    bits = o1 << 16 | o2 << 8 | o3;
-
-    h1 = bits >> 18 & 0x3f;
-    h2 = bits >> 12 & 0x3f;
-    h3 = bits >> 6 & 0x3f;
-    h4 = bits & 0x3f;
-
-    // use hexets to index into b64, and append result to encoded string
-    tmp_arr[ac++] = b64.charAt(h1) + b64.charAt(h2) + b64.charAt(h3) + b64.charAt(h4);
-  } while (i < data.length);
-
-  enc = tmp_arr.join('');
-
-  var r = data.length % 3;
-
-  return (r ? enc.slice(0, r - 3) : enc) + '==='.slice(r || 3);
+  return Out;
 }


### PR DESCRIPTION
Much shorter and quicker algorithm, plus minifies nicely:

function R_B64Encode(V){if(!V)return V;V=unescape(encodeURIComponent(V));var A=new Uint8Array(V),i=A.length,b="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",D="",M=252,S=6,C=0,x=0;while(x<i){D+=b[(C<<S)|((M&A[x])>>(8-S))];if(!S){M=252;S=6;C=0;}else{C=((~M)&A[x])S-=2;M=(M<<2)&255;}if(S)x++;}if(C)D+=b[(C<<S)];return D}