### PR TITLE
Remove '?' sign after parse string

### DIFF
--- a/functions/strings/parse_str.js
+++ b/functions/strings/parse_str.js
@@ -31,6 +31,7 @@ function parse_str(str, array) {
 
   var strArr = String(str)
     .replace(/^&/, '')
+    .replace(/^\?/, '')
     .replace(/&$/, '')
     .split('&'),
     sal = strArr.length,


### PR DESCRIPTION
When string parse directly form url query string using ```window.location.search``` then remove '?' sign after parsing.