### PR TITLE
python/capwords: Optimise variable assignment

### DIFF
--- a/src/python/string/capwords.js
+++ b/src/python/string/capwords.js
@@ -12,10 +12,7 @@ module.exports = function capwords (str) {
   //   returns 2: 'HELLO WORLD'
 
   var pattern = /^([a-z\u00E0-\u00FC])|\s+([a-z\u00E0-\u00FC])/g
-  str = (str + '')
-  str = str.replace(pattern, function ($1) {
+  return (str + '').replace(pattern, function ($1) {
     return $1.toUpperCase()
   })
-
-  return str
 }


### PR DESCRIPTION
There is a penalty in V8 for re-assigning a function parameter
as variable at run-time. Either use a new variable name or, in
this case, rewrite the code as a single statement without it.