### PR TITLE
Fix base64 window mode bug. Fixes #111

### DIFF
--- a/src/php/url/base64_decode.js
+++ b/src/php/url/base64_decode.js
@@ -18,7 +18,7 @@ module.exports = function base64_decode (encodedData) { // eslint-disable-line c
 
   if (typeof window !== 'undefined') {
     if (typeof window.atob !== 'undefined') {
-      return decodeURIComponent(unescape(window.atob(encodedData)))
+      return decodeURIComponent(escape(window.atob(encodedData)))
     }
   } else {
     return new Buffer(encodedData, 'base64').toString('utf-8')

--- a/src/php/url/base64_encode.js
+++ b/src/php/url/base64_encode.js
@@ -16,7 +16,7 @@ module.exports = function base64_encode (stringToEncode) { // eslint-disable-lin
 
   if (typeof window !== 'undefined') {
     if (typeof window.btoa !== 'undefined') {
-      return window.btoa(escape(encodeURIComponent(stringToEncode)))
+      return window.btoa(unescape(encodeURIComponent(stringToEncode)))
     }
   } else {
     return new Buffer(stringToEncode).toString('base64')


### PR DESCRIPTION
There is an error in base64_encode / decode function in window mode.

The tests pass OK because it doesn't run in window mode. Maybe the project should do some tests with karma.

base64_encode escapes the string twice.

https://developer.mozilla.org/es/docs/Web/API/WindowBase64/btoa#Unicode_strings