### PR TITLE
Fixes bcmul scale error, adds more tests

### DIFF
--- a/src/php/_helpers/_bc.js
+++ b/src/php/_helpers/_bc.js
@@ -436,7 +436,8 @@ module.exports = function _bc () { // eslint-disable-line camelcase
 
       // Assign to prod and clean up the number.
       pval.n_sign = (n1.n_sign === n2.n_sign ? Libbcmath.PLUS : Libbcmath.MINUS)
-        // pval.n_value = pval.nPtr; // @todo: pval.n_len = len2 + len1 + 1 - fullScale
+        // pval.n_value = pval.nPtr;
+      pval.n_len = len2 + len1 + 1 - fullScale
       pval.n_scale = prodScale
       Libbcmath._bc_rm_leading_zeros(pval)
       if (Libbcmath.bc_is_zero(pval)) {

--- a/src/php/bc/bcadd.js
+++ b/src/php/bc/bcadd.js
@@ -1,9 +1,12 @@
 module.exports = function bcadd (leftOperand, rightOperand, scale) {
   //  discuss at: http://locutus.io/php/bcadd/
   // original by: lmeyrick (https://sourceforge.net/projects/bcmath-js/)
-  //   example 1: bcadd(1, 2)
+  //   example 1: bcadd('1', '2')
   //   returns 1: '3'
-  // @todo: implement these testcases
+  //   example 2: bcadd('-1', '5', 4)
+  //   returns 2: '4.0000'
+  //   example 3: bcadd('1928372132132819737213', '8728932001983192837219398127471', 2)
+  //   returns 3: '8728932003911564969352217864684.00'
 
   var bc = require('../_helpers/_bc')
   var libbcmath = bc()

--- a/src/php/bc/bccomp.js
+++ b/src/php/bc/bccomp.js
@@ -1,8 +1,14 @@
 module.exports = function bccomp (leftOperand, rightOperand, scale) {
   //  discuss at: http://locutus.io/php/bccomp/
   // original by: lmeyrick (https://sourceforge.net/projects/bcmath-js/)
-  //   example 1: bccomp(1, 2)
+  //   example 1: bccomp('-1', '5', 4)
   //   returns 1: -1
+  //   example 2: bccomp('1928372132132819737213', '8728932001983192837219398127471')
+  //   returns 2: -1
+  //   example 3: bccomp('1.00000000000000000001', '1', 2)
+  //   returns 3: 0
+  //   example 4: bccomp('97321', '2321')
+  //   returns 4: 1
 
   var bc = require('../_helpers/_bc')
   var libbcmath = bc()

--- a/src/php/bc/bcdiv.js
+++ b/src/php/bc/bcdiv.js
@@ -1,9 +1,14 @@
 module.exports = function bcdiv (leftOperand, rightOperand, scale) {
   //  discuss at: http://locutus.io/php/bcdiv/
   // original by: lmeyrick (https://sourceforge.net/projects/bcmath-js/)
-  //   example 1: bcdiv(1, 2)
+  //   example 1: bcdiv('1', '2')
   //   returns 1: '0'
-  // @todo: implement these testcases
+  //   example 2: bcdiv('1', '2', 2)
+  //   returns 2: '0.50'
+  //   example 3: bcdiv('-1', '5', 4)
+  //   returns 3: '-0.2000'
+  //   example 4: bcdiv('8728932001983192837219398127471', '1928372132132819737213', 2)
+  //   returns 4: '4526580661.75'
 
   var _bc = require('../_helpers/_bc')
   var libbcmath = _bc()

--- a/src/php/bc/bcmul.js
+++ b/src/php/bc/bcmul.js
@@ -1,8 +1,14 @@
 module.exports = function bcmul (leftOperand, rightOperand, scale) {
   //  discuss at: http://locutus.io/php/bcmul/
   // original by: lmeyrick (https://sourceforge.net/projects/bcmath-js/)
-  //   example 1: bcmul(1, 2)
+  //   example 1: bcmul('1', '2')
   //   returns 1: '2'
+  //   example 2: bcmul('-3', '5')
+  //   returns 2: '-15'
+  //   example 3: bcmul('1234567890', '9876543210')
+  //   returns 3: '12193263111263526900'
+  //   example 4: bcmul('2.5', '1.5', 2)
+  //   returns 4: '3.75'
 
   var _bc = require('../_helpers/_bc')
   var libbcmath = _bc()

--- a/src/php/bc/bcsub.js
+++ b/src/php/bc/bcsub.js
@@ -1,8 +1,12 @@
 module.exports = function bcsub (leftOperand, rightOperand, scale) {
   //  discuss at: http://locutus.io/php/bcsub/
   // original by: lmeyrick (https://sourceforge.net/projects/bcmath-js/)
-  //   example 1: bcsub(1, 2)
+  //   example 1: bcsub('1', '2')
   //   returns 1: '-1'
+  //   example 2: bcsub('-1', '5', 4)
+  //   returns 2: '-6.0000'
+  //   example 3: bcsub('8728932001983192837219398127471', '1928372132132819737213', 2)
+  //   returns 3: '8728932000054820705086578390258.00'
 
   var _bc = require('../_helpers/_bc')
   var libbcmath = _bc()

--- a/test/languages/php/array/test-array_search.js
+++ b/test/languages/php/array/test-array_search.js
@@ -13,4 +13,10 @@ describe.skip('src/php/array/array_search.js (tested in test/languages/php/array
     expect(result).to.deep.equal(expected)
     done()
   })
+  it('should pass example 2', function (done) {
+    var expected = 'a'
+    var result = array_search('3', {a: 3, b: 5, c: 7})
+    expect(result).to.deep.equal(expected)
+    done()
+  })
 })

--- a/test/languages/php/bc/test-bcadd.js
+++ b/test/languages/php/bc/test-bcadd.js
@@ -9,7 +9,19 @@ var bcadd = require('../../../../src/php/bc/bcadd.js') // eslint-disable-line no
 describe('src/php/bc/bcadd.js (tested in test/languages/php/bc/test-bcadd.js)', function () {
   it('should pass example 1', function (done) {
     var expected = '3'
-    var result = bcadd(1, 2)
+    var result = bcadd('1', '2')
+    expect(result).to.deep.equal(expected)
+    done()
+  })
+  it('should pass example 2', function (done) {
+    var expected = '4.0000'
+    var result = bcadd('-1', '5', 4)
+    expect(result).to.deep.equal(expected)
+    done()
+  })
+  it('should pass example 3', function (done) {
+    var expected = '8728932003911564969352217864684.00'
+    var result = bcadd('1928372132132819737213', '8728932001983192837219398127471', 2)
     expect(result).to.deep.equal(expected)
     done()
   })

--- a/test/languages/php/bc/test-bccomp.js
+++ b/test/languages/php/bc/test-bccomp.js
@@ -9,7 +9,25 @@ var bccomp = require('../../../../src/php/bc/bccomp.js') // eslint-disable-line 
 describe('src/php/bc/bccomp.js (tested in test/languages/php/bc/test-bccomp.js)', function () {
   it('should pass example 1', function (done) {
     var expected = -1
-    var result = bccomp(1, 2)
+    var result = bccomp('-1', '5', 4)
+    expect(result).to.deep.equal(expected)
+    done()
+  })
+  it('should pass example 2', function (done) {
+    var expected = -1
+    var result = bccomp('1928372132132819737213', '8728932001983192837219398127471')
+    expect(result).to.deep.equal(expected)
+    done()
+  })
+  it('should pass example 3', function (done) {
+    var expected = 0
+    var result = bccomp('1.00000000000000000001', '1', 2)
+    expect(result).to.deep.equal(expected)
+    done()
+  })
+  it('should pass example 4', function (done) {
+    var expected = 1
+    var result = bccomp('97321', '2321')
     expect(result).to.deep.equal(expected)
     done()
   })

--- a/test/languages/php/bc/test-bcdiv.js
+++ b/test/languages/php/bc/test-bcdiv.js
@@ -9,7 +9,25 @@ var bcdiv = require('../../../../src/php/bc/bcdiv.js') // eslint-disable-line no
 describe('src/php/bc/bcdiv.js (tested in test/languages/php/bc/test-bcdiv.js)', function () {
   it('should pass example 1', function (done) {
     var expected = '0'
-    var result = bcdiv(1, 2)
+    var result = bcdiv('1', '2')
+    expect(result).to.deep.equal(expected)
+    done()
+  })
+  it('should pass example 2', function (done) {
+    var expected = '0.50'
+    var result = bcdiv('1', '2', 2)
+    expect(result).to.deep.equal(expected)
+    done()
+  })
+  it('should pass example 3', function (done) {
+    var expected = '-0.2000'
+    var result = bcdiv('-1', '5', 4)
+    expect(result).to.deep.equal(expected)
+    done()
+  })
+  it('should pass example 4', function (done) {
+    var expected = '4526580661.75'
+    var result = bcdiv('8728932001983192837219398127471', '1928372132132819737213', 2)
     expect(result).to.deep.equal(expected)
     done()
   })

--- a/test/languages/php/bc/test-bcmul.js
+++ b/test/languages/php/bc/test-bcmul.js
@@ -9,7 +9,25 @@ var bcmul = require('../../../../src/php/bc/bcmul.js') // eslint-disable-line no
 describe('src/php/bc/bcmul.js (tested in test/languages/php/bc/test-bcmul.js)', function () {
   it('should pass example 1', function (done) {
     var expected = '2'
-    var result = bcmul(1, 2)
+    var result = bcmul('1', '2')
+    expect(result).to.deep.equal(expected)
+    done()
+  })
+  it('should pass example 2', function (done) {
+    var expected = '-15'
+    var result = bcmul('-3', '5')
+    expect(result).to.deep.equal(expected)
+    done()
+  })
+  it('should pass example 3', function (done) {
+    var expected = '12193263111263526900'
+    var result = bcmul('1234567890', '9876543210')
+    expect(result).to.deep.equal(expected)
+    done()
+  })
+  it('should pass example 4', function (done) {
+    var expected = '3.75'
+    var result = bcmul('2.5', '1.5', 2)
     expect(result).to.deep.equal(expected)
     done()
   })

--- a/test/languages/php/bc/test-bcsub.js
+++ b/test/languages/php/bc/test-bcsub.js
@@ -9,7 +9,19 @@ var bcsub = require('../../../../src/php/bc/bcsub.js') // eslint-disable-line no
 describe('src/php/bc/bcsub.js (tested in test/languages/php/bc/test-bcsub.js)', function () {
   it('should pass example 1', function (done) {
     var expected = '-1'
-    var result = bcsub(1, 2)
+    var result = bcsub('1', '2')
+    expect(result).to.deep.equal(expected)
+    done()
+  })
+  it('should pass example 2', function (done) {
+    var expected = '-6.0000'
+    var result = bcsub('-1', '5', 4)
+    expect(result).to.deep.equal(expected)
+    done()
+  })
+  it('should pass example 3', function (done) {
+    var expected = '8728932000054820705086578390258.00'
+    var result = bcsub('8728932001983192837219398127471', '1928372132132819737213', 2)
     expect(result).to.deep.equal(expected)
     done()
   })

--- a/test/languages/php/strings/test-nl2br.js
+++ b/test/languages/php/strings/test-nl2br.js
@@ -25,4 +25,10 @@ describe('src/php/strings/nl2br.js (tested in test/languages/php/strings/test-nl
     expect(result).to.deep.equal(expected)
     done()
   })
+  it('should pass example 4', function (done) {
+    var expected = ''
+    var result = nl2br(null)
+    expect(result).to.deep.equal(expected)
+    done()
+  })
 })


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/kvz/locutus/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/kvz/locutus/pulls) for the same update/change?

### Description
`bcmul` worked fine without the scope parameter defined ( defaults to 0 ), but failed to calculate correctly when any scope > 0 was provided because of a commented line of logic in `_bc.js:bc_multiply()`

I compared the code side by side with php source ( https://github.com/php/php-src/blob/6053987bc27e8dede37f437193a5cad448f99bce/ext/bcmath/libbcmath/src/recmul.c#L278 ) and to be honest it's a little over my head but the issue with the scale was directly related to `pval.n_len` not being set correctly. Uncommenting the @todo line fixes the issue.

Additionally, I "rewrote" the tests for all of the `bc*` methods ( except for `bcround` which isn't an actual php function ) based on the basic tests that php/php-src uses ( https://github.com/php/php-src/tree/6053987bc27e8dede37f437193a5cad448f99bce/ext/bcmath/tests ). Everything passes now.