### PR TITLE
Use decodeURIComponent as unescape is deprecated in typescript

### DIFF
--- a/src/php/url/base64_encode.js
+++ b/src/php/url/base64_encode.js
@@ -16,7 +16,7 @@ module.exports = function base64_encode (stringToEncode) { // eslint-disable-lin
 
   if (typeof window !== 'undefined') {
     if (typeof window.btoa !== 'undefined') {
-      return window.btoa(unescape(encodeURIComponent(stringToEncode)))
+      return window.btoa(decodeURIComponent(encodeURIComponent(stringToEncode)))
     }
   } else {
     return new Buffer(stringToEncode).toString('base64')
@@ -40,7 +40,7 @@ module.exports = function base64_encode (stringToEncode) { // eslint-disable-lin
     return stringToEncode
   }
 
-  stringToEncode = unescape(encodeURIComponent(stringToEncode))
+  stringToEncode = decodeURIComponent(encodeURIComponent(stringToEncode))
 
   do {
     // pack three octets into four hexets


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/kvz/locutus/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/kvz/locutus/pulls) for the same update/change?

### Description
