### PR TITLE
Use encodeURIComponent as encode is deprecated in typescript

### DIFF
--- a/src/php/url/base64_decode.js
+++ b/src/php/url/base64_decode.js
@@ -18,7 +18,7 @@ module.exports = function base64_decode (encodedData) { // eslint-disable-line c
 
   if (typeof window !== 'undefined') {
     if (typeof window.atob !== 'undefined') {
-      return decodeURIComponent(escape(window.atob(encodedData)))
+      return decodeURIComponent(encodeURIComponent(window.atob(encodedData)))
     }
   } else {
     return new Buffer(encodedData, 'base64').toString('utf-8')
@@ -68,5 +68,5 @@ module.exports = function base64_decode (encodedData) { // eslint-disable-line c
 
   dec = tmpArr.join('')
 
-  return decodeURIComponent(escape(dec.replace(/\0+$/, '')))
+  return decodeURIComponent(encodeURIComponent(dec.replace(/\0+$/, '')))
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/kvz/locutus/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/kvz/locutus/pulls) for the same update/change?

### Description
