### PR TITLE
Improvements for base64_encode and base64_decode functions for UTF8 strings

### DIFF
--- a/src/php/url/base64_decode.js
+++ b/src/php/url/base64_decode.js
@@ -9,6 +9,7 @@ module.exports = function base64_decode (encodedData) { // eslint-disable-line c
   // bugfixed by: Onno Marsman (https://twitter.com/onnomarsman)
   // bugfixed by: Pellentesque Malesuada
   // bugfixed by: Kevin van Zonneveld (http://kvz.io)
+  // improved by: Indigo744
   //   example 1: base64_decode('S2V2aW4gdmFuIFpvbm5ldmVsZA==')
   //   returns 1: 'Kevin van Zonneveld'
   //   example 2: base64_decode('YQ==')

--- a/src/php/url/base64_decode.js
+++ b/src/php/url/base64_decode.js
@@ -16,16 +16,16 @@ module.exports = function base64_decode (encodedData) { // eslint-disable-line c
   //   returns 2: 'a'
   //   example 3: base64_decode('4pyTIMOgIGxhIG1vZGU=')
   //   returns 3: '✓ à la mode'
-  
+
   // decodeUTF8string()
   // Internal function to decode properly UTF8 string
   // Adapted from Solution #1 at https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding
-  var decodeUTF8string = function(str) {
+  var decodeUTF8string = function (str) {
     // Going backwards: from bytestream, to percent-encoding, to original string.
-    return decodeURIComponent(str.split('').map(function(c) {
-        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
-    }).join(''));
-  };
+    return decodeURIComponent(str.split('').map(function (c) {
+      return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+    }).join(''))
+  }
 
   if (typeof window !== 'undefined') {
     if (typeof window.atob !== 'undefined') {

--- a/src/php/url/base64_decode.js
+++ b/src/php/url/base64_decode.js
@@ -15,10 +15,20 @@ module.exports = function base64_decode (encodedData) { // eslint-disable-line c
   //   returns 2: 'a'
   //   example 3: base64_decode('4pyTIMOgIGxhIG1vZGU=')
   //   returns 3: '✓ à la mode'
+  
+  // decodeUTF8string()
+  // Internal function to decode properly UTF8 string
+  // Adapted from Solution #1 at https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding
+  var decodeUTF8string = function(str) {
+    // Going backwards: from bytestream, to percent-encoding, to original string.
+    return decodeURIComponent(str.split('').map(function(c) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+    }).join(''));
+  };
 
   if (typeof window !== 'undefined') {
     if (typeof window.atob !== 'undefined') {
-      return decodeURIComponent(encodeURIComponent(window.atob(encodedData)))
+      return decodeUTF8string(window.atob(encodedData))
     }
   } else {
     return new Buffer(encodedData, 'base64').toString('utf-8')
@@ -68,5 +78,5 @@ module.exports = function base64_decode (encodedData) { // eslint-disable-line c
 
   dec = tmpArr.join('')
 
-  return decodeURIComponent(encodeURIComponent(dec.replace(/\0+$/, '')))
+  return decodeUTF8string(dec.replace(/\0+$/, ''))
 }

--- a/src/php/url/base64_encode.js
+++ b/src/php/url/base64_encode.js
@@ -14,19 +14,19 @@ module.exports = function base64_encode (stringToEncode) { // eslint-disable-lin
   //   returns 2: 'YQ=='
   //   example 3: base64_encode('✓ à la mode')
   //   returns 3: '4pyTIMOgIGxhIG1vZGU='
-  
+
   // encodeUTF8string()
   // Internal function to encode properly UTF8 string
   // Adapted from Solution #1 at https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding
-  var encodeUTF8string = function(str) {
+  var encodeUTF8string = function (str) {
     // first we use encodeURIComponent to get percent-encoded UTF-8,
     // then we convert the percent encodings into raw bytes which
     // can be fed into the base64 encoding algorithm.
       return encodeURIComponent(str).replace(/%([0-9A-F]{2})/g,
-          function toSolidBytes(match, p1) {
-              return String.fromCharCode('0x' + p1);
-          });
-  };
+          function toSolidBytes (match, p1) {
+            return String.fromCharCode('0x' + p1)
+          })
+  }
 
   if (typeof window !== 'undefined') {
     if (typeof window.btoa !== 'undefined') {

--- a/src/php/url/base64_encode.js
+++ b/src/php/url/base64_encode.js
@@ -23,9 +23,9 @@ module.exports = function base64_encode (stringToEncode) { // eslint-disable-lin
     // then we convert the percent encodings into raw bytes which
     // can be fed into the base64 encoding algorithm.
       return encodeURIComponent(str).replace(/%([0-9A-F]{2})/g,
-          function toSolidBytes (match, p1) {
-            return String.fromCharCode('0x' + p1)
-          })
+        function toSolidBytes (match, p1) {
+          return String.fromCharCode('0x' + p1)
+        })
   }
 
   if (typeof window !== 'undefined') {

--- a/src/php/url/base64_encode.js
+++ b/src/php/url/base64_encode.js
@@ -7,6 +7,7 @@ module.exports = function base64_encode (stringToEncode) { // eslint-disable-lin
   // improved by: Kevin van Zonneveld (http://kvz.io)
   // improved by: Rafał Kukawski (http://blog.kukawski.pl)
   // bugfixed by: Pellentesque Malesuada
+  // improved by: Indigo744
   //   example 1: base64_encode('Kevin van Zonneveld')
   //   returns 1: 'S2V2aW4gdmFuIFpvbm5ldmVsZA=='
   //   example 2: base64_encode('a')

--- a/src/php/url/base64_encode.js
+++ b/src/php/url/base64_encode.js
@@ -22,10 +22,10 @@ module.exports = function base64_encode (stringToEncode) { // eslint-disable-lin
     // first we use encodeURIComponent to get percent-encoded UTF-8,
     // then we convert the percent encodings into raw bytes which
     // can be fed into the base64 encoding algorithm.
-      return encodeURIComponent(str).replace(/%([0-9A-F]{2})/g,
-        function toSolidBytes (match, p1) {
-          return String.fromCharCode('0x' + p1)
-        })
+    return encodeURIComponent(str).replace(/%([0-9A-F]{2})/g,
+      function toSolidBytes (match, p1) {
+        return String.fromCharCode('0x' + p1)
+      })
   }
 
   if (typeof window !== 'undefined') {

--- a/src/php/url/base64_encode.js
+++ b/src/php/url/base64_encode.js
@@ -13,10 +13,23 @@ module.exports = function base64_encode (stringToEncode) { // eslint-disable-lin
   //   returns 2: 'YQ=='
   //   example 3: base64_encode('✓ à la mode')
   //   returns 3: '4pyTIMOgIGxhIG1vZGU='
+  
+  // encodeUTF8string()
+  // Internal function to encode properly UTF8 string
+  // Adapted from Solution #1 at https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding
+  var encodeUTF8string = function(str) {
+    // first we use encodeURIComponent to get percent-encoded UTF-8,
+    // then we convert the percent encodings into raw bytes which
+    // can be fed into the base64 encoding algorithm.
+      return encodeURIComponent(str).replace(/%([0-9A-F]{2})/g,
+          function toSolidBytes(match, p1) {
+              return String.fromCharCode('0x' + p1);
+          });
+  };
 
   if (typeof window !== 'undefined') {
     if (typeof window.btoa !== 'undefined') {
-      return window.btoa(decodeURIComponent(encodeURIComponent(stringToEncode)))
+      return window.btoa(encodeUTF8string(stringToEncode))
     }
   } else {
     return new Buffer(stringToEncode).toString('base64')
@@ -40,7 +53,7 @@ module.exports = function base64_encode (stringToEncode) { // eslint-disable-lin
     return stringToEncode
   }
 
-  stringToEncode = decodeURIComponent(encodeURIComponent(stringToEncode))
+  stringToEncode = encodeUTF8string(stringToEncode)
 
   do {
     // pack three octets into four hexets


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/kvz/locutus/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/kvz/locutus/pulls) for the same update/change?

### Description
Improved `base_64_encode()` and `base64_decode()` function to properly handle UTF8 strings, as suggested by Mozilla in https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding in solution 1 of chapter _The "Unicode Problem"_

Tested in Mozilla Firefox 53 and Google Chrome 58.
Tested against PHP own functions.