### PR TITLE
frexp Math.log2 fallback and removed use of Math.sign

### DIFF
--- a/src/c/math/frexp.js
+++ b/src/c/math/frexp.js
@@ -61,7 +61,7 @@ module.exports = function frexp (arg) {
     }
 
     if (arg < 0) {
-      x = -x;
+      x = -x
     }
     result[0] = x
     result[1] = exp

--- a/src/c/math/frexp.js
+++ b/src/c/math/frexp.js
@@ -60,7 +60,9 @@ module.exports = function frexp (arg) {
       exp++
     }
 
-    x *= Math.sign(arg)
+    if (arg < 0) {
+      x = -x;
+    }
     result[0] = x
     result[1] = exp
   }

--- a/src/c/math/frexp.js
+++ b/src/c/math/frexp.js
@@ -44,7 +44,9 @@ module.exports = function frexp (arg) {
 
   if (arg !== 0 && Number.isFinite(arg)) {
     const absArg = Math.abs(arg)
-    let exp = Math.max(-1023, Math.floor(Math.log2(absArg)) + 1)
+    // Math.log2 was introduced in ES2015, use it when available
+    const log2 = Math.log2 || function log2 (n) { return Math.log(n) * Math.LOG2E }
+    let exp = Math.max(-1023, Math.floor(log2(absArg)) + 1)
     let x = absArg * Math.pow(2, -exp)
 
     // These while loops compensate for rounding errors that sometimes occur because of ECMAScript's Math.log2's undefined precision


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/kvz/locutus/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/kvz/locutus/pulls) for the same update/change?

### Description
Fixes the Node 0.10 failure at https://travis-ci.org/kvz/locutus/builds/233204495?utm_source=github_status&utm_medium=notification (relevant pull request: https://github.com/kvz/locutus/pull/331 )
Old ECMAScript implementations don't have `Math.log2`, so we fall back on using `function log2 (n) { return Math.log(n) * Math.LOG2E }`