### PR TITLE
PHP.ucwords - add multibyte support

### DIFF
--- a/src/php/strings/ucwords.js
+++ b/src/php/strings/ucwords.js
@@ -5,6 +5,7 @@ module.exports = function ucwords (str) {
   // improved by: Robin
   // improved by: Kevin van Zonneveld (http://kvz.io)
   // bugfixed by: Onno Marsman (https://twitter.com/onnomarsman)
+  // bugfixed by: Cetvertacov Alexandr (https://github.com/cetver)
   //    input by: James (http://www.james-bell.co.uk/)
   //   example 1: ucwords('kevin van  zonneveld')
   //   returns 1: 'Kevin Van  Zonneveld'

--- a/src/php/strings/ucwords.js
+++ b/src/php/strings/ucwords.js
@@ -10,9 +10,13 @@ module.exports = function ucwords (str) {
   //   returns 1: 'Kevin Van  Zonneveld'
   //   example 2: ucwords('HELLO WORLD')
   //   returns 2: 'HELLO WORLD'
+  //   example 3: ucwords('у мэри был маленький ягненок и она его очень любила')
+  //   returns 3: 'У Мэри Был Маленький Ягненок И Она Его Очень Любила'
+  //   example 4: ucwords('τάχιστη αλώπηξ βαφής ψημένη γη, δρασκελίζει υπέρ νωθρού κυνός')
+  //   returns 4: 'Τάχιστη Αλώπηξ Βαφής Ψημένη Γη, Δρασκελίζει Υπέρ Νωθρού Κυνός'
 
   return (str + '')
-    .replace(/^([a-z\u00E0-\u00FC])|\s+([a-z\u00E0-\u00FC])/g, function ($1) {
+    .replace(/^(.)|\s+(.)/g, function ($1) {
       return $1.toUpperCase()
     })
 }

--- a/test/languages/php/strings/test-ucwords.js
+++ b/test/languages/php/strings/test-ucwords.js
@@ -19,4 +19,16 @@ describe('src/php/strings/ucwords.js (tested in test/languages/php/strings/test-
     expect(result).to.deep.equal(expected)
     done()
   })
+  it('should pass example 3', function (done) {
+    var expected = 'У Мэри Был Маленький Ягненок И Она Его Очень Любила'
+    var result = ucwords('у мэри был маленький ягненок и она его очень любила')
+    expect(result).to.deep.equal(expected)
+    done()
+  })
+  it('should pass example 4', function (done) {
+    var expected = 'Τάχιστη Αλώπηξ Βαφής Ψημένη Γη, Δρασκελίζει Υπέρ Νωθρού Κυνός'
+    var result = ucwords('τάχιστη αλώπηξ βαφής ψημένη γη, δρασκελίζει υπέρ νωθρού κυνός')
+    expect(result).to.deep.equal(expected)
+    done()
+  })
 })


### PR DESCRIPTION
The problem:

\+ expected \- actual

\-у мэри был маленький ягненок и она его очень любила
\+У Мэри Был Маленький Ягненок И Она Его Очень Любила

\-τάχιστη αλώπηξ βαφής ψημένη γη, δρασκελίζει υπέρ νωθρού κυνός
\+Τάχιστη Αλώπηξ Βαφής Ψημένη Γη, Δρασκελίζει Υπέρ Νωθρού Κυνός

This patch will fix it.