### PR TITLE
Rounding problem

### DIFF
--- a/src/php/strings/number_format.js
+++ b/src/php/strings/number_format.js
@@ -56,14 +56,21 @@ module.exports = function number_format (number, decimals, decPoint, thousandsSe
   var dec = (typeof decPoint === 'undefined') ? '.' : decPoint
   var s = ''
 
-  var toFixedFix = function (n, prec) {
-    var k = Math.pow(10, prec)
-    return '' + (Math.round(n * k) / k)
-      .toFixed(prec)
+  var toFixedFix = function (n,prec) {
+    if (!("" + n).includes("e")) {
+        return +(Math.round(n + "e+" + prec) + "e-" + prec);
+    } else {
+      var arr = ("" + n).split("e");
+      var sig = ""
+      if (+arr[1] + prec > 0) {
+          sig = "+";
+      }
+      return +(Math.round(+arr[0] + "e" + sig + (+arr[1] + prec)) + "e-" + prec);
+    }
   }
 
   // @todo: for IE parseFloat(0.55).toFixed(0) = 0;
-  s = (prec ? toFixedFix(n, prec) : '' + Math.round(n)).split('.')
+  s = (prec ? toFixedFix(n, prec).toString() : '' + Math.round(n)).split('.')
   if (s[0].length > 3) {
     s[0] = s[0].replace(/\B(?=(?:\d{3})+(?!\d))/g, sep)
   }

--- a/src/php/strings/number_format.js
+++ b/src/php/strings/number_format.js
@@ -56,16 +56,16 @@ module.exports = function number_format (number, decimals, decPoint, thousandsSe
   var dec = (typeof decPoint === 'undefined') ? '.' : decPoint
   var s = ''
 
-  var toFixedFix = function (n,prec) {
-    if (!("" + n).includes("e")) {
-        return +(Math.round(n + "e+" + prec) + "e-" + prec);
+  var toFixedFix = function (n, prec) {
+    if (('' + n).indexOf('e') == -1) {
+      return +(Math.round(n + 'e+' + prec) + 'e-' + prec)
     } else {
-      var arr = ("" + n).split("e");
-      var sig = ""
+      var arr = ('' + n).split('e')
+      var sig = ''
       if (+arr[1] + prec > 0) {
-          sig = "+";
+        sig = '+'
       }
-      return +(Math.round(+arr[0] + "e" + sig + (+arr[1] + prec)) + "e-" + prec);
+      return +(Math.round(+arr[0] + 'e' + sig + (+arr[1] + prec)) + 'e-' + prec)
     }
   }
 

--- a/src/php/strings/number_format.js
+++ b/src/php/strings/number_format.js
@@ -65,7 +65,7 @@ module.exports = function number_format (number, decimals, decPoint, thousandsSe
       if (+arr[1] + prec > 0) {
         sig = '+'
       }
-      return +(Math.round(+arr[0] + 'e' + sig + (+arr[1] + prec)) + 'e-' + prec)
+      return (+(Math.round(+arr[0] + 'e' + sig + (+arr[1] + prec)) + 'e-' + prec)).toFixed(prec)
     }
   }
 

--- a/src/php/strings/number_format.js
+++ b/src/php/strings/number_format.js
@@ -57,7 +57,7 @@ module.exports = function number_format (number, decimals, decPoint, thousandsSe
   var s = ''
 
   var toFixedFix = function (n, prec) {
-    if (('' + n).indexOf('e') == -1) {
+    if (('' + n).indexOf('e') === -1) {
       return +(Math.round(n + 'e+' + prec) + 'e-' + prec)
     } else {
       var arr = ('' + n).split('e')


### PR DESCRIPTION
The function is rouding some numbers wrong:

Example 1: number_format(35.855,2,",",".")
Result 1: 35,85 the corret result is 35,86

Example 2: number_format(33.6750,2,",",".")
Result 1: 33,67 the corret result is 33,68

my changes fix that, i got the rounding fuction from: 
https://stackoverflow.com/questions/11832914/round-to-at-most-2-decimal-places-only-if-necessary

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/kvz/locutus/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/kvz/locutus/pulls) for the same update/change?

### Description
