### PR TITLE
Fix issue #339: sprintf format trouble

### DIFF
--- a/src/php/strings/sprintf.js
+++ b/src/php/strings/sprintf.js
@@ -21,7 +21,7 @@ module.exports = function sprintf () {
   //   example 5: sprintf('%-03s', 'E')
   //   returns 5: 'E00'
 
-  var regex = /%%|%(\d+\$)?([-+'#0 ]*)(\*\d+\$|\*|\d+)?(?:\.(\*\d+\$|\*|\d+))?([scboxXuideEfFgG])/g
+  var regex = /%%|%(\d+\$)?([-+'#0 ]*)(\*\d+\$|\*|\d+)?(?:\.(\d*))?([scboxXuideEfFgG])/g
   var a = arguments
   var i = 0
   var format = a[i++]
@@ -134,10 +134,6 @@ module.exports = function sprintf () {
 
     if (!precision) {
       precision = 'fFeE'.indexOf(type) > -1 ? 6 : (type === 'd') ? 0 : undefined
-    } else if (precision === '*') {
-      precision = +a[i++]
-    } else if (precision.charAt(0) === '*') {
-      precision = +a[precision.slice(1, -1)]
     } else {
       precision = +precision
     }


### PR DESCRIPTION
Precision digits are optional, a standalone dot is also considered valid.
Removed also precision handling which is not supported by PHP

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/kvz/locutus/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/kvz/locutus/pulls) for the same update/change?

### Description
