### PR TITLE
Convert Non-strict to strict equality checking

### DIFF
--- a/src/php/strings/levenshtein.js
+++ b/src/php/strings/levenshtein.js
@@ -15,7 +15,7 @@ module.exports = function levenshtein (s1, s2, costIns, costRep, costDel) {
 
   // var LEVENSHTEIN_MAX_LENGTH = 255 // PHP limits the function to max 255 character-long strings
 
-  costIns = costIns == null ? 1 : +costIns
+  costIns = costIns === null ? 1 : +costIns
   costRep = costRep == null ? 1 : +costRep
   costDel = costDel == null ? 1 : +costDel
 

--- a/website/themes/icarus/scripts/thumbnail.js
+++ b/website/themes/icarus/scripts/thumbnail.js
@@ -20,7 +20,7 @@ hexo.extend.helper.register('thumbnail', function (post) {
                     url = post.path + ret[1];
                 }
             } else if ((ret = pattern_.exec(url)) != null) {
-                if(ret[0].length == url.length) {
+                if(ret[0].length === url.length) {
                     url = post.path + ret[1];
                 }
             }

--- a/website/themes/icarus/scripts/thumbnail.js
+++ b/website/themes/icarus/scripts/thumbnail.js
@@ -16,7 +16,7 @@ hexo.extend.helper.register('thumbnail', function (post) {
             var pattern = /^[\\{0,1}\/{0,1}]([^\/^\\]+)/,
                 pattern_ = /([^\/^\\]+)/;
             if ((ret = pattern.exec(url)) != null) {
-                if(ret[0].length == url.length) {
+                if(ret[0].length === url.length) {
                     url = post.path + ret[1];
                 }
             } else if ((ret = pattern_.exec(url)) != null) {

--- a/website/themes/icarus/scripts/thumbnail.js
+++ b/website/themes/icarus/scripts/thumbnail.js
@@ -19,7 +19,7 @@ hexo.extend.helper.register('thumbnail', function (post) {
                 if(ret[0].length === url.length) {
                     url = post.path + ret[1];
                 }
-            } else if ((ret = pattern_.exec(url)) != null) {
+            } else if ((ret = pattern_.exec(url)) !== null) {
                 if(ret[0].length === url.length) {
                     url = post.path + ret[1];
                 }

--- a/website/themes/icarus/scripts/thumbnail.js
+++ b/website/themes/icarus/scripts/thumbnail.js
@@ -15,7 +15,7 @@ hexo.extend.helper.register('thumbnail', function (post) {
         if(url.length > 0) {
             var pattern = /^[\\{0,1}\/{0,1}]([^\/^\\]+)/,
                 pattern_ = /([^\/^\\]+)/;
-            if ((ret = pattern.exec(url)) != null) {
+            if ((ret = pattern.exec(url)) !== null) {
                 if(ret[0].length === url.length) {
                     url = post.path + ret[1];
                 }

--- a/website/themes/icarus/source/js/insight.js
+++ b/website/themes/icarus/source/js/insight.js
@@ -17,7 +17,7 @@
 
     function searchItem (icon, title, slug, preview, url) {
         return $('<div>').addClass('ins-selectable').addClass('ins-search-item')
-            .append($('<header>').append($('<i>').addClass('fa').addClass('fa-' + icon)).append(title != null && title != '' ? title : CONFIG.TRANSLATION['UNTITLED'])
+            .append($('<header>').append($('<i>').addClass('fa').addClass('fa-' + icon)).append(title !== null && title !== '' ? title : CONFIG.TRANSLATION['UNTITLED'])
                 .append(slug ? $('<span>').addClass('ins-slug').text(slug) : null))
             .append(preview ? $('<p>').addClass('ins-search-preview').text(preview) : null)
             .attr('data-url', url);


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/kvz/locutus/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/kvz/locutus/pulls) for the same update/change?

### Description
Strict equality checks are desired in JS, so you don't rely on implicit type coercion.
In these particular scenarios, `RegExp.exec` will return `null` if the match fails.
And `String.length` will always return a `Number`, so the logic won't be affected.