### PR TITLE
Fix npm run build:tests

### DIFF
--- a/src/_util/util.js
+++ b/src/_util/util.js
@@ -630,7 +630,7 @@ class Util {
     var i = 0
     var lines = []
     var raise = false
-    for (i in (lines = code.replace('\r', '').split('\n'))) {
+    for (i in (lines = code.replace(/\r+/g, '').split('\n'))) {
       // Detect if line is a comment, and return the actual comment
       if ((comment = lines[i].match(/^\s*(\/\/|\/\*|\*)\s*(.*)$/))) {
         if (raise === true) {


### PR DESCRIPTION
Building tests was failing locally with Error: No example in "randomFunctionName".
Parsing comments sometimes didn't work properly due to carriage return characters.
It turned out that not all \r were removed.