### PR TITLE
correct _utf8Size function  & add exemple

### DIFF
--- a/src/php/var/serialize.js
+++ b/src/php/var/serialize.js
@@ -30,7 +30,7 @@ module.exports = function serialize (mixedValue) {
   var count = 0
 
   var _utf8Size = function (str) {
-    return ~-encodeURI(str).split(/%..|./).length;
+    return ~-encodeURI(str).split(/%..|./).length
   }
 
   var _getType = function (inp) {

--- a/src/php/var/serialize.js
+++ b/src/php/var/serialize.js
@@ -11,6 +11,7 @@ module.exports = function serialize (mixedValue) {
   // bugfixed by: Kevin van Zonneveld (http://kvz.io/)
   // bugfixed by: Ben (http://benblume.co.uk/)
   // bugfixed by: Codestar (http://codestarlive.com/)
+  // bugfixed by: idjem (https://github.com/idjem)
   //    input by: DtTvB (http://dt.in.th/2008-09-16.string-length-in-bytes.html)
   //    input by: Martin (http://www.erlenwiese.de/)
   //      note 1: We feel the main purpose of this function should be to ease
@@ -20,6 +21,8 @@ module.exports = function serialize (mixedValue) {
   //   returns 1: 'a:3:{i:0;s:5:"Kevin";i:1;s:3:"van";i:2;s:9:"Zonneveld";}'
   //   example 2: serialize({firstName: 'Kevin', midName: 'van'})
   //   returns 2: 'a:2:{s:9:"firstName";s:5:"Kevin";s:7:"midName";s:3:"van";}'
+  //   example 3: serialize( {'ü': 'ü', '四': '四', '𠜎': '𠜎'})
+  //   returns 3: 'a:3:{s:2:"ü";s:2:"ü";s:3:"四";s:3:"四";s:4:"𠜎";s:4:"𠜎";}'
 
   var val, key, okey
   var ktype = ''
@@ -27,21 +30,7 @@ module.exports = function serialize (mixedValue) {
   var count = 0
 
   var _utf8Size = function (str) {
-    var size = 0
-    var i = 0
-    var l = str.length
-    var code = ''
-    for (i = 0; i < l; i++) {
-      code = str.charCodeAt(i)
-      if (code < 0x0080) {
-        size += 1
-      } else if (code < 0x0800) {
-        size += 2
-      } else {
-        size += 3
-      }
-    }
-    return size
+    return ~-encodeURI(str).split(/%..|./).length;
   }
 
   var _getType = function (inp) {

--- a/test/languages/php/var/test-serialize.js
+++ b/test/languages/php/var/test-serialize.js
@@ -19,4 +19,10 @@ describe('src/php/var/serialize.js (tested in test/languages/php/var/test-serial
     expect(result).to.deep.equal(expected)
     done()
   })
+  it('should pass example 3', function (done) {
+    var expected = 'a:3:{s:2:"ü";s:2:"ü";s:3:"四";s:3:"四";s:4:"𠜎";s:4:"𠜎";}'
+    var result = serialize( {'ü': 'ü', '四': '四', '𠜎': '𠜎'})
+    expect(result).to.deep.equal(expected)
+    done()
+  })
 })


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/kvz/locutus/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/kvz/locutus/pulls) for the same update/change?

### Description
correct _utf8Size  function and add exemple;
_utf8Size('𠜎') return 6 should be 4 
```
AssertionError: expected 'a:3:{s:2:"ü";s:2:"ü";s:3:"四";s:3:"四";s:6:"𠜎";s:6:"𠜎";}' to deeply equal 'a:3:{s:2:"ü";s:2:"ü";s:3:"四";s:3:"四";s:4:"𠜎";s:4:"𠜎";}'
```