### PR TITLE
Fixes #323

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,5 +87,9 @@
     "website:build": "cd website && hexo generate",
     "website:clean": "cd website && hexo clean"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "browser": {
+    "fs": false,
+    "child_process": false
+  }
 }


### PR DESCRIPTION
Better Webpack support based on https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module

- [x] Have you followed the guidelines in our [Contributing](https://github.com/kvz/locutus/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/kvz/locutus/pulls) for the same update/change?

### Description

Webpack builds sometimes break, because of the `fs` (or `child_process`) module can not be resolved in a browser environment. 

This should fix that.
