### PR TITLE
Add `encType` argument to the PHP `http_build_query` function

### DIFF
--- a/src/php/url/http_build_query.js
+++ b/src/php/url/http_build_query.js
@@ -1,4 +1,4 @@
-module.exports = function http_build_query (formdata, numericPrefix, argSeparator) { // eslint-disable-line camelcase
+module.exports = function http_build_query (formdata, numericPrefix, argSeparator, encType) { // eslint-disable-line camelcase
   //  discuss at: http://locutus.io/php/http_build_query/
   // original by: Kevin van Zonneveld (http://kvz.io)
   // improved by: Legaev Andrey
@@ -9,14 +9,28 @@ module.exports = function http_build_query (formdata, numericPrefix, argSeparato
   //    input by: Dreamer
   // bugfixed by: Brett Zamir (http://brett-zamir.me)
   // bugfixed by: MIO_KODUKI (http://mio-koduki.blogspot.com/)
+  // improved by: Will Rowe
   //      note 1: If the value is null, key and value are skipped in the
   //      note 1: http_build_query of PHP while in locutus they are not.
   //   example 1: http_build_query({foo: 'bar', php: 'hypertext processor', baz: 'boom', cow: 'milk'}, '', '&amp;')
   //   returns 1: 'foo=bar&amp;php=hypertext+processor&amp;baz=boom&amp;cow=milk'
   //   example 2: http_build_query({'php': 'hypertext processor', 0: 'foo', 1: 'bar', 2: 'baz', 3: 'boom', 'cow': 'milk'}, 'myvar_')
   //   returns 2: 'myvar_0=foo&myvar_1=bar&myvar_2=baz&myvar_3=boom&php=hypertext+processor&cow=milk'
+  //   example 3: http_build_query({foo: 'bar', php: 'hypertext processor', baz: 'boom', cow: 'milk'}, '', '&amp;', 'PHP_QUERY_RFC3986')
+  //   returns 3: 'foo=bar&amp;php=hypertext%20processor&amp;baz=boom&amp;cow=milk'
 
-  var urlencode = require('../url/urlencode')
+  var encodeFunc
+
+  switch (encType) {
+    case 'PHP_QUERY_RFC3986':
+      encodeFunc = require('../url/rawurlencode')
+      break
+
+    case 'PHP_QUERY_RFC1738':
+    default:
+      encodeFunc = require('../url/urlencode')
+      break
+  }
 
   var value
   var key
@@ -39,7 +53,7 @@ module.exports = function http_build_query (formdata, numericPrefix, argSeparato
         }
         return tmp.join(argSeparator)
       } else if (typeof val !== 'function') {
-        return urlencode(key) + '=' + urlencode(val)
+        return encodeFunc(key) + '=' + encodeFunc(val)
       } else {
         throw new Error('There was an error processing for http_build_query().')
       }

--- a/test/languages/php/url/test-http_build_query.js
+++ b/test/languages/php/url/test-http_build_query.js
@@ -19,4 +19,10 @@ describe('src/php/url/http_build_query.js (tested in test/languages/php/url/test
     expect(result).to.deep.equal(expected)
     done()
   })
+  it('should pass example 3', function (done) {
+    var expected = 'foo=bar&amp;php=hypertext%20processor&amp;baz=boom&amp;cow=milk'
+    var result = http_build_query({foo: 'bar', php: 'hypertext processor', baz: 'boom', cow: 'milk'}, '', '&amp;', 'PHP_QUERY_RFC3986')
+    expect(result).to.deep.equal(expected)
+    done()
+  })
 })


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/kvz/locutus/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/kvz/locutus/pulls) for the same update/change?

### Description
- This is a retry of https://github.com/kvz/locutus/pull/217 which was never merged due to testing issues at the time.
- Depending on the encoding type used, it will use either `urlencode` or `rawurlencode`.