### PR TITLE
Update strip_tags.js

### DIFF
--- a/src/php/strings/strip_tags.js
+++ b/src/php/strings/strip_tags.js
@@ -43,10 +43,13 @@ module.exports = function strip_tags (input, allowed) { // eslint-disable-line c
   // making sure the allowed arg is a string containing only tags in lowercase (<a><b><c>)
   allowed = (((allowed || '') + '').toLowerCase().match(/<[a-z][a-z0-9]*>/g) || []).join('')
 
-  var tags = /<\/?([a-z][a-z0-9]*)\b[^>]*>/gi
+  var tags = /<\/?([a-z0-9]*)\b[^>]*>?/gi
   var commentsAndPhpTags = /<!--[\s\S]*?-->|<\?(?:php)?[\s\S]*?\?>/gi
 
   var after = _phpCastString(input)
+  // removes tha '<' char at the end of the string to replicate PHP's behaviour
+  after = (after.substring(after.length - 1) === '<') ? after.substring(0, after.length - 1) : after
+
   // recursively remove tags to ensure that the returned string doesn't contain forbidden tags after previous passes (e.g. '<<bait/>switch/>')
   while (true) {
     var before = after


### PR DESCRIPTION
The strip_tags function on PHP removes chars after a broken tag (i.e. "<b" without the closing char ">") til the end of the string and removes the "<" char when its the last on the string. 
The proposed change removes the redundance on range matching regex string and adds a ? allowing to get that broken tags. Besides, it also checks the last char on the string and removes it when necessary.
