### PR TITLE
New strtotime implementation

### DIFF
--- a/src/php/datetime/strtotime.js
+++ b/src/php/datetime/strtotime.js
@@ -1,300 +1,1144 @@
-module.exports = function strtotime (text, now) {
-  //  discuss at: http://locutus.io/php/strtotime/
-  // original by: Caio Ariede (http://caioariede.com)
-  // improved by: Kevin van Zonneveld (http://kvz.io)
-  // improved by: Caio Ariede (http://caioariede.com)
-  // improved by: A. Matías Quezada (http://amatiasq.com)
-  // improved by: preuter
-  // improved by: Brett Zamir (http://brett-zamir.me)
-  // improved by: Mirko Faber
-  //    input by: David
-  // bugfixed by: Wagner B. Soares
-  // bugfixed by: Artur Tchernychev
-  // bugfixed by: Stephan Bösch-Plepelits (http://github.com/plepe)
-  //      note 1: Examples all have a fixed timestamp to prevent
-  //      note 1: tests to fail because of variable time(zones)
-  //   example 1: strtotime('+1 day', 1129633200)
-  //   returns 1: 1129719600
-  //   example 2: strtotime('+1 week 2 days 4 hours 2 seconds', 1129633200)
-  //   returns 2: 1130425202
-  //   example 3: strtotime('last month', 1129633200)
-  //   returns 3: 1127041200
-  //   example 4: strtotime('2009-05-04 08:30:00 GMT')
-  //   returns 4: 1241425800
-  //   example 5: strtotime('2009-05-04 08:30:00+00')
-  //   returns 5: 1241425800
-  //   example 6: strtotime('2009-05-04 08:30:00+02:00')
-  //   returns 6: 1241418600
-  //   example 7: strtotime('2009-05-04T08:30:00Z')
-  //   returns 7: 1241425800
+const reSpace = '[ \\t]+'
+const reSpaceOpt = '[ \\t]*'
+const reMeridian = '(?:([ap])\\.?m\\.?([\\t ]|$))'
+const reHour24 = '(2[0-4]|[01]?[0-9])'
+const reHour24lz = '([01][0-9]|2[0-4])'
+const reHour12 = '(0?[1-9]|1[0-2])'
+const reMinute = '([0-5]?[0-9])'
+const reMinutelz = '([0-5][0-9])'
+const reSecond = '(60|[0-5]?[0-9])'
+const reSecondlz = '(60|[0-5][0-9])'
+const reFrac = '(?:\\.([0-9]+))'
 
-  var parsed
-  var match
-  var today
-  var year
-  var date
-  var days
-  var ranges
-  var len
-  var times
-  var regex
-  var i
-  var fail = false
+const reDayfull = 'sunday|monday|tuesday|wednesday|thursday|friday|saturday'
+const reDayabbr = 'sun|mon|tue|wed|thu|fri|sat'
+const reDaytext = reDayfull + '|' + reDayabbr + '|weekdays?'
 
-  if (!text) {
-    return fail
+const reReltextnumber = 'first|second|third|fourth|fifth|sixth|seventh|eighth?|ninth|tenth|eleventh|twelfth'
+const reReltexttext = 'next|last|previous|this'
+const reReltextunit = '(?:second|sec|minute|min|hour|day|fortnight|forthnight|month|year)s?|weeks|' + reDaytext
+
+const reYear = '([0-9]{1,4})'
+const reYear2 = '([0-9]{2})'
+const reYear4 = '([0-9]{4})'
+const reYear4withSign = '([+-]?[0-9]{4})'
+const reMonth = '(1[0-2]|0?[0-9])'
+const reMonthlz = '(0[0-9]|1[0-2])'
+const reDay = '(?:(3[01]|[0-2]?[0-9])(?:st|nd|rd|th)?)'
+const reDaylz = '(0[0-9]|[1-2][0-9]|3[01])'
+
+const reMonthFull = 'january|february|march|april|may|june|july|august|september|october|november|december'
+const reMonthAbbr = 'jan|feb|mar|apr|may|jun|jul|aug|sept?|oct|nov|dec'
+const reMonthroman = 'i[vx]|vi{0,3}|xi{0,2}|i{1,3}'
+const reMonthText = '(' + reMonthFull + '|' + reMonthAbbr + '|' + reMonthroman + ')'
+
+const reTzCorrection = '((?:GMT)?([+-])' + reHour24 + ':?' + reMinute + '?)'
+const reDayOfYear = '(00[1-9]|0[1-9][0-9]|[12][0-9][0-9]|3[0-5][0-9]|36[0-6])'
+const reWeekOfYear = '(0[1-9]|[1-4][0-9]|5[0-3])'
+
+function processMeridian (hour, meridian) {
+  meridian = meridian && meridian.toLowerCase()
+
+  switch (meridian) {
+    case 'a':
+      hour += hour === 12 ? -12 : 0
+      break
+    case 'p':
+      hour += hour !== 12 ? 12 : 0
+      break
   }
 
-  // Unecessary spaces
-  text = text.replace(/^\s+|\s+$/g, '')
-    .replace(/\s{2,}/g, ' ')
-    .replace(/[\t\r\n]/g, '')
-    .toLowerCase()
+  return hour
+}
 
-  // in contrast to php, js Date.parse function interprets:
-  // dates given as yyyy-mm-dd as in timezone: UTC,
-  // dates with "." or "-" as MDY instead of DMY
-  // dates with two-digit years differently
-  // etc...etc...
-  // ...therefore we manually parse lots of common date formats
-  var pattern = new RegExp([
-    '^(\\d{1,4})',
-    '([\\-\\.\\/:])',
-    '(\\d{1,2})',
-    '([\\-\\.\\/:])',
-    '(\\d{1,4})',
-    '(?:\\s(\\d{1,2}):(\\d{2})?:?(\\d{2})?)?',
-    '(?:\\s([A-Z]+)?)?$'
-  ].join(''))
-  match = text.match(pattern)
+function processYear (yearStr) {
+  let year = +yearStr
 
-  if (match && match[2] === match[4]) {
-    if (match[1] > 1901) {
-      switch (match[2]) {
-        case '-':
-          // YYYY-M-D
-          if (match[3] > 12 || match[5] > 31) {
-            return fail
-          }
+  if (yearStr.length < 4 && year < 100) {
+    year += year < 70 ? 2000 : 1900
+  }
 
-          return new Date(match[1], parseInt(match[3], 10) - 1, match[5],
-          match[6] || 0, match[7] || 0, match[8] || 0, match[9] || 0) / 1000
-        case '.':
-          // YYYY.M.D is not parsed by strtotime()
-          return fail
-        case '/':
-          // YYYY/M/D
-          if (match[3] > 12 || match[5] > 31) {
-            return fail
-          }
+  return year
+}
 
-          return new Date(match[1], parseInt(match[3], 10) - 1, match[5],
-          match[6] || 0, match[7] || 0, match[8] || 0, match[9] || 0) / 1000
+function lookupMonth (monthStr) {
+  return {
+    jan: 0,
+    january: 0,
+    i: 0,
+    feb: 1,
+    february: 1,
+    ii: 1,
+    mar: 2,
+    march: 2,
+    iii: 2,
+    apr: 3,
+    april: 3,
+    iv: 3,
+    may: 4,
+    v: 4,
+    jun: 5,
+    june: 5,
+    vi: 5,
+    jul: 6,
+    july: 6,
+    vii: 6,
+    aug: 7,
+    august: 7,
+    viii: 7,
+    sep: 8,
+    sept: 8,
+    september: 8,
+    ix: 8,
+    oct: 9,
+    october: 9,
+    x: 9,
+    nov: 10,
+    november: 10,
+    xi: 10,
+    dec: 11,
+    december: 11,
+    xii: 11
+  }[monthStr.toLowerCase()]
+}
+
+function lookupWeekday (dayStr, desiredSundayNumber = 0) {
+  const dayNumbers = {
+    mon: 1,
+    monday: 1,
+    tue: 2,
+    tuesday: 2,
+    wed: 3,
+    wednesday: 3,
+    thu: 4,
+    thursday: 4,
+    fri: 5,
+    friday: 5,
+    sat: 6,
+    saturday: 6,
+    sun: 0,
+    sunday: 0
+  }
+
+  return dayNumbers[dayStr.toLowerCase()] || desiredSundayNumber
+}
+
+function lookupRelative (relText) {
+  const relativeNumbers = {
+    last: -1,
+    previous: -1,
+    this: 0,
+    first: 1,
+    next: 1,
+    second: 2,
+    third: 3,
+    fourth: 4,
+    fifth: 5,
+    sixth: 6,
+    seventh: 7,
+    eight: 8,
+    eighth: 8,
+    ninth: 9,
+    tenth: 10,
+    eleventh: 11,
+    twelfth: 12
+  }
+
+  const relativeBehavior = {
+    this: 1
+  }
+
+  const relTextLower = relText.toLowerCase()
+
+  return {
+    amount: relativeNumbers[relTextLower],
+    behavior: relativeBehavior[relTextLower] || 0
+  }
+}
+
+function processTzCorrection (tzOffset, oldValue) {
+  const reTzCorrectionLoose = /(?:GMT)?([+-])(\d+)(:?)(\d{0,2})/i
+  tzOffset = tzOffset && tzOffset.match(reTzCorrectionLoose)
+
+  if (!tzOffset) {
+    return oldValue
+  }
+
+  let sign = tzOffset[1] === '-' ? 1 : -1
+  let hours = +tzOffset[2]
+  let minutes = +tzOffset[4]
+
+  if (!tzOffset[4] && !tzOffset[3]) {
+    minutes = Math.floor(hours % 100)
+    hours = Math.floor(hours / 100)
+  }
+
+  return sign * (hours * 60 + minutes)
+}
+
+const formats = {
+  yesterday: {
+    regex: /^yesterday/i,
+    name: 'yesterday',
+    callback: function () {
+      this.rd -= 1
+      return this.resetTime()
+    }
+  },
+
+  now: {
+    regex: /^now/i,
+    name: 'now'
+    // do nothing
+  },
+
+  noon: {
+    regex: /^noon/i,
+    name: 'noon',
+    callback: function () {
+      return this.resetTime() && this.time(12, 0, 0, 0)
+    }
+  },
+
+  midnightOrToday: {
+    regex: /^(midnight|today)/i,
+    name: 'midnight | today',
+    callback: function () {
+      return this.resetTime()
+    }
+  },
+
+  tomorrow: {
+    regex: /^tomorrow/i,
+    name: 'tomorrow',
+    callback: function () {
+      this.rd += 1
+      return this.resetTime()
+    }
+  },
+
+  timestamp: {
+    regex: /^@(-?\d+)/i,
+    name: 'timestamp',
+    callback: function (match, timestamp) {
+      this.rs += +timestamp
+      this.y = 1970
+      this.m = 0
+      this.d = 1
+      this.dates = 0
+
+      return this.resetTime() && this.zone(0)
+    }
+  },
+
+  firstOrLastDay: {
+    regex: /^(first|last) day of/i,
+    name: 'firstdayof | lastdayof',
+    callback: function (match, day) {
+      if (day.toLowerCase() === 'first') {
+        this.firstOrLastDayOfMonth = 1
+      } else {
+        this.firstOrLastDayOfMonth = -1
       }
-    } else if (match[5] > 1901) {
-      switch (match[2]) {
-        case '-':
-          // D-M-YYYY
-          if (match[3] > 12 || match[1] > 31) {
-            return fail
-          }
-
-          return new Date(match[5], parseInt(match[3], 10) - 1, match[1],
-          match[6] || 0, match[7] || 0, match[8] || 0, match[9] || 0) / 1000
-        case '.':
-          // D.M.YYYY
-          if (match[3] > 12 || match[1] > 31) {
-            return fail
-          }
-
-          return new Date(match[5], parseInt(match[3], 10) - 1, match[1],
-          match[6] || 0, match[7] || 0, match[8] || 0, match[9] || 0) / 1000
-        case '/':
-          // M/D/YYYY
-          if (match[1] > 12 || match[3] > 31) {
-            return fail
-          }
-
-          return new Date(match[5], parseInt(match[1], 10) - 1, match[3],
-          match[6] || 0, match[7] || 0, match[8] || 0, match[9] || 0) / 1000
-      }
-    } else {
-      switch (match[2]) {
-        case '-':
-          // YY-M-D
-          if (match[3] > 12 || match[5] > 31 || (match[1] < 70 && match[1] > 38)) {
-            return fail
-          }
-
-          year = match[1] >= 0 && match[1] <= 38 ? +match[1] + 2000 : match[1]
-          return new Date(year, parseInt(match[3], 10) - 1, match[5],
-          match[6] || 0, match[7] || 0, match[8] || 0, match[9] || 0) / 1000
-        case '.':
-          // D.M.YY or H.MM.SS
-          if (match[5] >= 70) {
-            // D.M.YY
-            if (match[3] > 12 || match[1] > 31) {
-              return fail
-            }
-
-            return new Date(match[5], parseInt(match[3], 10) - 1, match[1],
-            match[6] || 0, match[7] || 0, match[8] || 0, match[9] || 0) / 1000
-          }
-          if (match[5] < 60 && !match[6]) {
-            // H.MM.SS
-            if (match[1] > 23 || match[3] > 59) {
-              return fail
-            }
-
-            today = new Date()
-            return new Date(today.getFullYear(), today.getMonth(), today.getDate(),
-            match[1] || 0, match[3] || 0, match[5] || 0, match[9] || 0) / 1000
-          }
-
-          // invalid format, cannot be parsed
-          return fail
-        case '/':
-          // M/D/YY
-          if (match[1] > 12 || match[3] > 31 || (match[5] < 70 && match[5] > 38)) {
-            return fail
-          }
-
-          year = match[5] >= 0 && match[5] <= 38 ? +match[5] + 2000 : match[5]
-          return new Date(year, parseInt(match[1], 10) - 1, match[3],
-          match[6] || 0, match[7] || 0, match[8] || 0, match[9] || 0) / 1000
-        case ':':
-          // HH:MM:SS
-          if (match[1] > 23 || match[3] > 59 || match[5] > 59) {
-            return fail
-          }
-
-          today = new Date()
-          return new Date(today.getFullYear(), today.getMonth(), today.getDate(),
-          match[1] || 0, match[3] || 0, match[5] || 0) / 1000
-      }
     }
-  }
+  },
 
-  // other formats and "now" should be parsed by Date.parse()
-  if (text === 'now') {
-    return now === null || isNaN(now)
-      ? new Date().getTime() / 1000 | 0
-      : now | 0
-  }
-  if (!isNaN(parsed = Date.parse(text))) {
-    return parsed / 1000 | 0
-  }
-  // Browsers !== Chrome have problems parsing ISO 8601 date strings, as they do
-  // not accept lower case characters, space, or shortened time zones.
-  // Therefore, fix these problems and try again.
-  // Examples:
-  //   2015-04-15 20:33:59+02
-  //   2015-04-15 20:33:59z
-  //   2015-04-15t20:33:59+02:00
-  pattern = new RegExp([
-    '^([0-9]{4}-[0-9]{2}-[0-9]{2})',
-    '[ t]',
-    '([0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?)',
-    '([\\+-][0-9]{2}(:[0-9]{2})?|z)'
-  ].join(''))
-  match = text.match(pattern)
-  if (match) {
-    // @todo: time zone information
-    if (match[4] === 'z') {
-      match[4] = 'Z'
-    } else if (match[4].match(/^([+-][0-9]{2})$/)) {
-      match[4] = match[4] + ':00'
-    }
+  backOrFrontOf: {
+    regex: RegExp('^(back|front) of ' + reHour24 + reSpaceOpt + reMeridian + '?', 'i'),
+    name: 'backof | frontof',
+    callback: function (match, side, hours, meridian) {
+      let back = side.toLowerCase() === 'back'
+      let hour = +hours
+      let minute = 15
 
-    if (!isNaN(parsed = Date.parse(match[1] + 'T' + match[2] + match[4]))) {
-      return parsed / 1000 | 0
-    }
-  }
-
-  date = now ? new Date(now * 1000) : new Date()
-  days = {
-    'sun': 0,
-    'mon': 1,
-    'tue': 2,
-    'wed': 3,
-    'thu': 4,
-    'fri': 5,
-    'sat': 6
-  }
-  ranges = {
-    'yea': 'FullYear',
-    'mon': 'Month',
-    'day': 'Date',
-    'hou': 'Hours',
-    'min': 'Minutes',
-    'sec': 'Seconds'
-  }
-
-  function lastNext (type, range, modifier) {
-    var diff
-    var day = days[range]
-
-    if (typeof day !== 'undefined') {
-      diff = day - date.getDay()
-
-      if (diff === 0) {
-        diff = 7 * modifier
-      } else if (diff > 0 && type === 'last') {
-        diff -= 7
-      } else if (diff < 0 && type === 'next') {
-        diff += 7
+      if (!back) {
+        hour -= 1
+        minute = 45
       }
 
-      date.setDate(date.getDate() + diff)
+      hour = processMeridian(hour, meridian)
+
+      return this.resetTime() && this.time(hour, minute, 0, 0)
+    }
+  },
+
+  weekdayOf: {
+    regex: RegExp('^(' + reReltextnumber + '|' + reReltexttext + ')' + reSpace + '(' + reDayfull + '|' + reDayabbr + ')' + reSpace + 'of', 'i'),
+    name: 'weekdayof'
+    // todo
+  },
+
+  mssqltime: {
+    regex: RegExp('^' + reHour12 + ':' + reMinutelz + ':' + reSecondlz + '[:.]([0-9]+)' + reMeridian, 'i'),
+    name: 'mssqltime',
+    callback: function (match, hour, minute, second, frac, meridian) {
+      return this.time(processMeridian(+hour, meridian), +minute, +second, +frac.substr(0, 3))
+    }
+  },
+
+  timeLong12: {
+    regex: RegExp('^' + reHour12 + '[:.]' + reMinute + '[:.]' + reSecondlz + reSpaceOpt + reMeridian, 'i'),
+    name: 'timelong12',
+    callback: function (match, hour, minute, second, meridian) {
+      return this.time(processMeridian(+hour, meridian), +minute, +second, 0)
+    }
+  },
+
+  timeShort12: {
+    regex: RegExp('^' + reHour12 + '[:.]' + reMinutelz + reSpaceOpt + reMeridian, 'i'),
+    name: 'timeshort12',
+    callback: function (match, hour, minute, meridian) {
+      return this.time(processMeridian(+hour, meridian), +minute, 0, 0)
+    }
+  },
+
+  timeTiny12: {
+    regex: RegExp('^' + reHour12 + reSpaceOpt + reMeridian, 'i'),
+    name: 'timetiny12',
+    callback: function (match, hour, meridian) {
+      return this.time(processMeridian(+hour, meridian), 0, 0, 0)
+    }
+  },
+
+  soap: {
+    regex: RegExp('^' + reYear4 + '-' + reMonthlz + '-' + reDaylz + 'T' + reHour24lz + ':' + reMinutelz + ':' + reSecondlz + reFrac + reTzCorrection + '?', 'i'),
+    name: 'soap',
+    callback: function (match, year, month, day, hour, minute, second, frac, tzCorrection) {
+      return this.ymd(+year, month - 1, +day) &&
+              this.time(+hour, +minute, +second, +frac.substr(0, 3)) &&
+              this.zone(processTzCorrection(tzCorrection))
+    }
+  },
+
+  wddx: {
+    regex: RegExp('^' + reYear4 + '-' + reMonth + '-' + reDay + 'T' + reHour24 + ':' + reMinute + ':' + reSecond),
+    name: 'wddx',
+    callback: function (match, year, month, day, hour, minute, second) {
+      return this.ymd(+year, month - 1, +day) && this.time(+hour, +minute, +second, 0)
+    }
+  },
+
+  exif: {
+    regex: RegExp('^' + reYear4 + ':' + reMonthlz + ':' + reDaylz + ' ' + reHour24lz + ':' + reMinutelz + ':' + reSecondlz, 'i'),
+    name: 'exif',
+    callback: function (match, year, month, day, hour, minute, second) {
+      return this.ymd(+year, month - 1, +day) && this.time(+hour, +minute, +second, 0)
+    }
+  },
+
+  xmlRpc: {
+    regex: RegExp('^' + reYear4 + reMonthlz + reDaylz + 'T' + reHour24 + ':' + reMinutelz + ':' + reSecondlz),
+    name: 'xmlrpc',
+    callback: function (match, year, month, day, hour, minute, second) {
+      return this.ymd(+year, month - 1, +day) && this.time(+hour, +minute, +second, 0)
+    }
+  },
+
+  xmlRpcNoColon: {
+    regex: RegExp('^' + reYear4 + reMonthlz + reDaylz + '[Tt]' + reHour24 + reMinutelz + reSecondlz),
+    name: 'xmlrpcnocolon',
+    callback: function (match, year, month, day, hour, minute, second) {
+      return this.ymd(+year, month - 1, +day) && this.time(+hour, +minute, +second, 0)
+    }
+  },
+
+  clf: {
+    regex: RegExp('^' + reDay + '/(' + reMonthAbbr + ')/' + reYear4 + ':' + reHour24lz + ':' + reMinutelz + ':' + reSecondlz + reSpace + reTzCorrection, 'i'),
+    name: 'clf',
+    callback: function (match, day, month, year, hour, minute, second, tzCorrection) {
+      return this.ymd(+year, lookupMonth(month), +day) &&
+              this.time(+hour, +minute, +second, 0) &&
+              this.zone(processTzCorrection(tzCorrection))
+    }
+  },
+
+  iso8601long: {
+    regex: RegExp('^t?' + reHour24 + '[:.]' + reMinute + '[:.]' + reSecond + reFrac, 'i'),
+    name: 'iso8601long',
+    callback: function (match, hour, minute, second, frac) {
+      return this.time(+hour, +minute, +second, +frac.substr(0, 3))
+    }
+  },
+
+  dateTextual: {
+    regex: RegExp('^' + reMonthText + '[ .\\t-]*' + reDay + '[,.stndrh\\t ]+' + reYear, 'i'),
+    name: 'datetextual',
+    callback: function (match, month, day, year) {
+      return this.ymd(processYear(year), lookupMonth(month), +day)
+    }
+  },
+
+  pointedDate4: {
+    regex: RegExp('^' + reDay + '[.\\t-]' + reMonth + '[.-]' + reYear4),
+    name: 'pointeddate4',
+    callback: function (match, day, month, year) {
+      return this.ymd(+year, month - 1, +day)
+    }
+  },
+
+  pointedDate2: {
+    regex: RegExp('^' + reDay + '[.\\t]' + reMonth + '\\.' + reYear2),
+    name: 'pointeddate2',
+    callback: function (match, day, month, year) {
+      return this.ymd(processYear(year), month - 1, +day)
+    }
+  },
+
+  timeLong24: {
+    regex: RegExp('^t?' + reHour24 + '[:.]' + reMinute + '[:.]' + reSecond),
+    name: 'timelong24',
+    callback: function (match, hour, minute, second) {
+      return this.time(+hour, +minute, +second, 0)
+    }
+  },
+
+  dateNoColon: {
+    regex: RegExp('^' + reYear4 + reMonthlz + reDaylz),
+    name: 'datenocolon',
+    callback: function (match, year, month, day) {
+      return this.ymd(+year, month - 1, +day)
+    }
+  },
+
+  pgydotd: {
+    regex: RegExp('^' + reYear4 + '\\.?' + reDayOfYear),
+    name: 'pgydotd',
+    callback: function (match, year, day) {
+      return this.ymd(+year, 0, +day)
+    }
+  },
+
+  timeShort24: {
+    regex: RegExp('^t?' + reHour24 + '[:.]' + reMinute, 'i'),
+    name: 'timeshort24',
+    callback: function (match, hour, minute) {
+      return this.time(+hour, +minute, 0, 0)
+    }
+  },
+
+  iso8601noColon: {
+    regex: RegExp('^t?' + reHour24lz + reMinutelz + reSecondlz, 'i'),
+    name: 'iso8601nocolon',
+    callback: function (match, hour, minute, second) {
+      return this.time(+hour, +minute, +second, 0)
+    }
+  },
+
+  iso8601dateSlash: {
+    // eventhough the trailing slash is optional in PHP
+    // here it's mandatory and inputs without the slash
+    // are handled by dateslash
+    regex: RegExp('^' + reYear4 + '/' + reMonthlz + '/' + reDaylz + '/'),
+    name: 'iso8601dateslash',
+    callback: function (match, year, month, day) {
+      return this.ymd(+year, month - 1, +day)
+    }
+  },
+
+  dateSlash: {
+    regex: RegExp('^' + reYear4 + '/' + reMonth + '/' + reDay),
+    name: 'dateslash',
+    callback: function (match, year, month, day) {
+      return this.ymd(+year, month - 1, +day)
+    }
+  },
+
+  american: {
+    regex: RegExp('^' + reMonth + '/' + reDay + '/' + reYear),
+    name: 'american',
+    callback: function (match, month, day, year) {
+      return this.ymd(processYear(year), month - 1, +day)
+    }
+  },
+
+  americanShort: {
+    regex: RegExp('^' + reMonth + '/' + reDay),
+    name: 'americanshort',
+    callback: function (match, month, day) {
+      return this.ymd(this.y, month - 1, +day)
+    }
+  },
+
+  gnuDateShortOrIso8601date2: {
+    // iso8601date2 is complete subset of gnudateshort
+    regex: RegExp('^' + reYear + '-' + reMonth + '-' + reDay),
+    name: 'gnudateshort | iso8601date2',
+    callback: function (match, year, month, day) {
+      return this.ymd(processYear(year), month - 1, +day)
+    }
+  },
+
+  iso8601date4: {
+    regex: RegExp('^' + reYear4withSign + '-' + reMonthlz + '-' + reDaylz),
+    name: 'iso8601date4',
+    callback: function (match, year, month, day) {
+      return this.ymd(+year, month - 1, +day)
+    }
+  },
+
+  gnuNoColon: {
+    regex: RegExp('^t' + reHour24lz + reMinutelz, 'i'),
+    name: 'gnunocolon',
+    callback: function (match, hour, minute) {
+      return this.time(+hour, +minute, 0, this.f)
+    }
+  },
+
+  gnuDateShorter: {
+    regex: RegExp('^' + reYear4 + '-' + reMonth),
+    name: 'gnudateshorter',
+    callback: function (match, year, month) {
+      return this.ymd(+year, month - 1, 1)
+    }
+  },
+
+  pgTextReverse: {
+    // note: allowed years are from 32-9999
+    // years below 32 should be treated as days in datefull
+    regex: RegExp('^' + '(\\d{3,4}|[4-9]\\d|3[2-9])-(' + reMonthAbbr + ')-' + reDaylz, 'i'),
+    name: 'pgtextreverse',
+    callback: function (match, year, month, day) {
+      return this.ymd(processYear(year), lookupMonth(month), +day)
+    }
+  },
+
+  dateFull: {
+    regex: RegExp('^' + reDay + '[ \\t.-]*' + reMonthText + '[ \\t.-]*' + reYear, 'i'),
+    name: 'datefull',
+    callback: function (match, day, month, year) {
+      return this.ymd(processYear(year), lookupMonth(month), +day)
+    }
+  },
+
+  dateNoDay: {
+    regex: RegExp('^' + reMonthText + '[ .\\t-]*' + reYear4, 'i'),
+    name: 'datenoday',
+    callback: function (match, month, year) {
+      return this.ymd(+year, lookupMonth(month), 1)
+    }
+  },
+
+  dateNoDayRev: {
+    regex: RegExp('^' + reYear4 + '[ .\\t-]*' + reMonthText, 'i'),
+    name: 'datenodayrev',
+    callback: function (match, year, month) {
+      return this.ymd(+year, lookupMonth(month), 1)
+    }
+  },
+
+  pgTextShort: {
+    regex: RegExp('^(' + reMonthAbbr + ')-' + reDaylz + '-' + reYear, 'i'),
+    name: 'pgtextshort',
+    callback: function (match, month, day, year) {
+      return this.ymd(processYear(year), lookupMonth(month), +day)
+    }
+  },
+
+  dateNoYear: {
+    regex: RegExp('^' + reMonthText + '[ .\\t-]*' + reDay + '[,.stndrh\\t ]*', 'i'),
+    name: 'datenoyear',
+    callback: function (match, month, day) {
+      return this.ymd(this.y, lookupMonth(month), +day)
+    }
+  },
+
+  dateNoYearRev: {
+    regex: RegExp('^' + reDay + '[ .\\t-]*' + reMonthText, 'i'),
+    name: 'datenoyearrev',
+    callback: function (match, day, month) {
+      return this.ymd(this.y, lookupMonth(month), +day)
+    }
+  },
+
+  isoWeekDay: {
+    regex: RegExp('^' + reYear4 + '-?W' + reWeekOfYear + '(?:-?([0-7]))?'),
+    name: 'isoweekday | isoweek',
+    callback: function (match, year, week, day) {
+      day = day ? +day : 1
+
+      if (!this.ymd(+year, 0, 1)) {
+        return false
+      }
+
+      // get day of week for Jan 1st
+      let dayOfWeek = new Date(this.y, this.m, this.d).getDay()
+
+      // and use the day to figure out the offset for day 1 of week 1
+      dayOfWeek = 0 - (dayOfWeek > 4 ? dayOfWeek - 7 : dayOfWeek)
+
+      this.rd += dayOfWeek + ((week - 1) * 7) + day
+    }
+  },
+
+  relativeText: {
+    regex: RegExp('^(' + reReltextnumber + '|' + reReltexttext + ')' + reSpace + '(' + reReltextunit + ')', 'i'),
+    name: 'relativetext',
+    callback: function (match, relValue, relUnit) {
+      // todo: implement handling of 'this time-unit'
+      // eslint-disable-next-line no-unused-vars
+      const { amount, behavior } = lookupRelative(relValue)
+
+      switch (relUnit.toLowerCase()) {
+        case 'sec':
+        case 'secs':
+        case 'second':
+        case 'seconds':
+          this.rs += amount
+          break
+        case 'min':
+        case 'mins':
+        case 'minute':
+        case 'minutes':
+          this.ri += amount
+          break
+        case 'hour':
+        case 'hours':
+          this.rh += amount
+          break
+        case 'day':
+        case 'days':
+          this.rd += amount
+          break
+        case 'fortnight':
+        case 'fortnights':
+        case 'forthnight':
+        case 'forthnights':
+          this.rd += amount * 14
+          break
+        case 'week':
+        case 'weeks':
+          this.rd += amount * 7
+          break
+        case 'month':
+        case 'months':
+          this.rm += amount
+          break
+        case 'year':
+        case 'years':
+          this.ry += amount
+          break
+        case 'mon': case 'monday':
+        case 'tue': case 'tuesday':
+        case 'wed': case 'wednesday':
+        case 'thu': case 'thursday':
+        case 'fri': case 'friday':
+        case 'sat': case 'saturday':
+        case 'sun': case 'sunday':
+          this.resetTime()
+          this.weekday = lookupWeekday(relUnit, 7)
+          this.weekdayBehavior = 1
+          this.rd += (amount > 0 ? amount - 1 : amount) * 7
+          break
+        case 'weekday':
+        case 'weekdays':
+          // todo
+          break
+      }
+    }
+  },
+
+  relative: {
+    regex: RegExp('^([+-]*)[ \\t]*(\\d+)' + reSpaceOpt + '(' + reReltextunit + '|week)', 'i'),
+    name: 'relative',
+    callback: function (match, signs, relValue, relUnit) {
+      const minuses = signs.replace(/[^-]/g, '').length
+
+      let amount = +relValue * Math.pow(-1, minuses)
+
+      switch (relUnit.toLowerCase()) {
+        case 'sec':
+        case 'secs':
+        case 'second':
+        case 'seconds':
+          this.rs += amount
+          break
+        case 'min':
+        case 'mins':
+        case 'minute':
+        case 'minutes':
+          this.ri += amount
+          break
+        case 'hour':
+        case 'hours':
+          this.rh += amount
+          break
+        case 'day':
+        case 'days':
+          this.rd += amount
+          break
+        case 'fortnight':
+        case 'fortnights':
+        case 'forthnight':
+        case 'forthnights':
+          this.rd += amount * 14
+          break
+        case 'week':
+        case 'weeks':
+          this.rd += amount * 7
+          break
+        case 'month':
+        case 'months':
+          this.rm += amount
+          break
+        case 'year':
+        case 'years':
+          this.ry += amount
+          break
+        case 'mon': case 'monday':
+        case 'tue': case 'tuesday':
+        case 'wed': case 'wednesday':
+        case 'thu': case 'thursday':
+        case 'fri': case 'friday':
+        case 'sat': case 'saturday':
+        case 'sun': case 'sunday':
+          this.resetTime()
+          this.weekday = lookupWeekday(relUnit, 7)
+          this.weekdayBehavior = 1
+          this.rd += (amount > 0 ? amount - 1 : amount) * 7
+          break
+        case 'weekday':
+        case 'weekdays':
+          // todo
+          break
+      }
+    }
+  },
+
+  dayText: {
+    regex: RegExp('^(' + reDaytext + ')', 'i'),
+    name: 'daytext',
+    callback: function (match, dayText) {
+      this.resetTime()
+      this.weekday = lookupWeekday(dayText, 0)
+
+      if (this.weekdayBehavior !== 2) {
+        this.weekdayBehavior = 1
+      }
+    }
+  },
+
+  relativeTextWeek: {
+    regex: RegExp('^(' + reReltexttext + ')' + reSpace + 'week', 'i'),
+    name: 'relativetextweek',
+    callback: function (match, relText) {
+      this.weekdayBehavior = 2
+
+      switch (relText.toLowerCase()) {
+        case 'this':
+          this.rd += 0
+          break
+        case 'next':
+          this.rd += 7
+          break
+        case 'last':
+        case 'previous':
+          this.rd -= 7
+          break
+      }
+
+      if (isNaN(this.weekday)) {
+        this.weekday = 1
+      }
+    }
+  },
+
+  monthFullOrMonthAbbr: {
+    regex: RegExp('^(' + reMonthFull + '|' + reMonthAbbr + ')', 'i'),
+    name: 'monthfull | monthabbr',
+    callback: function (match, month) {
+      return this.ymd(this.y, lookupMonth(month), this.d)
+    }
+  },
+
+  tzCorrection: {
+    regex: RegExp('^' + reTzCorrection, 'i'),
+    name: 'tzcorrection',
+    callback: function (tzCorrection) {
+      return this.zone(processTzCorrection(tzCorrection))
+    }
+  },
+
+  ago: {
+    regex: /^ago/i,
+    name: 'ago',
+    callback: function () {
+      this.ry = -this.ry
+      this.rm = -this.rm
+      this.rd = -this.rd
+      this.rh = -this.rh
+      this.ri = -this.ri
+      this.rs = -this.rs
+      this.rf = -this.rf
+    }
+  },
+
+  gnuNoColon2: {
+    // second instance of gnunocolon, without leading 't'
+    // it's down here, because it is very generic (4 digits in a row)
+    // thus conflicts with many rules above
+    // only year4 should come afterwards
+    regex: RegExp('^' + reHour24lz + reMinutelz, 'i'),
+    name: 'gnunocolon',
+    callback: function (match, hour, minute) {
+      return this.time(+hour, +minute, 0, this.f)
+    }
+  },
+
+  year4: {
+    regex: RegExp('^' + reYear4),
+    name: 'year4',
+    callback: function (match, year) {
+      this.y = +year
+      return true
+    }
+  },
+
+  whitespace: {
+    regex: /^[ .,\t]+/,
+    name: 'whitespace'
+    // do nothing
+  },
+
+  any: {
+    regex: /^[\s\S]+/,
+    name: 'any',
+    callback: function () {
+      return false
     }
   }
+}
 
-  function process (val) {
-    // @todo: Reconcile this with regex using \s, taking into account
-    // browser issues with split and regexes
-    var splt = val.split(' ')
-    var type = splt[0]
-    var range = splt[1].substring(0, 3)
-    var typeIsNumber = /\d+/.test(type)
-    var ago = splt[2] === 'ago'
-    var num = (type === 'last' ? -1 : 1) * (ago ? -1 : 1)
+let resultProto = {
+  // date
+  y: NaN,
+  m: NaN,
+  d: NaN,
+  // time
+  h: NaN,
+  i: NaN,
+  s: NaN,
+  f: NaN,
 
-    if (typeIsNumber) {
-      num *= parseInt(type, 10)
-    }
+  // relative shifts
+  ry: 0,
+  rm: 0,
+  rd: 0,
+  rh: 0,
+  ri: 0,
+  rs: 0,
+  rf: 0,
 
-    if (ranges.hasOwnProperty(range) && !splt[1].match(/^mon(day|\.)?$/i)) {
-      return date['set' + ranges[range]](date['get' + ranges[range]]() + num)
-    }
+  // weekday related shifts
+  weekday: NaN,
+  weekdayBehavior: 0,
 
-    if (range === 'wee') {
-      return date.setDate(date.getDate() + (num * 7))
-    }
+  // first or last day of month
+  // 0 none, 1 first, -1 last
+  firstOrLastDayOfMonth: 0,
 
-    if (type === 'next' || type === 'last') {
-      lastNext(type, range, num)
-    } else if (!typeIsNumber) {
+  // timezone correction in minutes
+  z: NaN,
+
+  // counters
+  dates: 0,
+  times: 0,
+  zones: 0,
+
+  // helper functions
+  ymd: function (y, m, d) {
+    if (this.dates > 0) {
       return false
     }
 
+    this.dates++
+    this.y = y
+    this.m = m
+    this.d = d
     return true
+  },
+
+  time: function (h, i, s, f) {
+    if (this.times > 0) {
+      return false
+    }
+
+    this.times++
+    this.h = h
+    this.i = i
+    this.s = s
+    this.f = f
+
+    return true
+  },
+
+  resetTime: function () {
+    this.h = 0
+    this.i = 0
+    this.s = 0
+    this.f = 0
+    this.times = 0
+
+    return true
+  },
+
+  zone: function (minutes) {
+    if (this.zones <= 1) {
+      this.zones++
+      this.z = minutes
+      return true
+    }
+
+    return false
+  },
+
+  toDate: function (relativeTo) {
+    if (this.dates && !this.times) {
+      this.h = this.i = this.s = this.f = 0
+    }
+
+    // fill holes
+    if (isNaN(this.y)) {
+      this.y = relativeTo.getFullYear()
+    }
+
+    if (isNaN(this.m)) {
+      this.m = relativeTo.getMonth()
+    }
+
+    if (isNaN(this.d)) {
+      this.d = relativeTo.getDate()
+    }
+
+    if (isNaN(this.h)) {
+      this.h = relativeTo.getHours()
+    }
+
+    if (isNaN(this.i)) {
+      this.i = relativeTo.getMinutes()
+    }
+
+    if (isNaN(this.s)) {
+      this.s = relativeTo.getSeconds()
+    }
+
+    if (isNaN(this.f)) {
+      this.f = relativeTo.getMilliseconds()
+    }
+
+    // adjust special early
+    switch (this.firstOrLastDayOfMonth) {
+      case 1:
+        this.d = 1
+        break
+      case -1:
+        this.d = 0
+        this.m += 1
+        break
+    }
+
+    if (!isNaN(this.weekday)) {
+      var date = new Date(relativeTo.getTime())
+      date.setFullYear(this.y, this.m, this.d)
+      date.setHours(this.h, this.i, this.s, this.f)
+
+      var dow = date.getDay()
+
+      if (this.weekdayBehavior === 2) {
+        // To make "this week" work, where the current day of week is a "sunday"
+        if (dow === 0 && this.weekday !== 0) {
+          this.weekday = -6
+        }
+
+        // To make "sunday this week" work, where the current day of week is not a "sunday"
+        if (this.weekday === 0 && dow !== 0) {
+          this.weekday = 7
+        }
+
+        this.d -= dow
+        this.d += this.weekday
+      } else {
+        var diff = this.weekday - dow
+
+        // some PHP magic
+        if ((this.rd < 0 && diff < 0) || (this.rd >= 0 && diff <= -this.weekdayBehavior)) {
+          diff += 7
+        }
+
+        if (this.weekday >= 0) {
+          this.d += diff
+        } else {
+          this.d -= (7 - (Math.abs(this.weekday) - dow))
+        }
+
+        this.weekday = NaN
+      }
+    }
+
+    // adjust relative
+    this.y += this.ry
+    this.m += this.rm
+    this.d += this.rd
+
+    this.h += this.rh
+    this.i += this.ri
+    this.s += this.rs
+    this.f += this.rf
+
+    this.ry = this.rm = this.rd = 0
+    this.rh = this.ri = this.rs = this.rf = 0
+
+    let result = new Date(relativeTo.getTime())
+    // since Date constructor treats years <= 99 as 1900+
+    // it can't be used, thus this weird way
+    result.setFullYear(this.y, this.m, this.d)
+    result.setHours(this.h, this.i, this.s, this.f)
+
+    // note: this is done twice in PHP
+    // early when processing special relatives
+    // and late
+    // todo: check if the logic can be reduced
+    // to just one time action
+    switch (this.firstOrLastDayOfMonth) {
+      case 1:
+        result.setDate(1)
+        break
+      case -1:
+        result.setMonth(result.getMonth() + 1, 0)
+        break
+    }
+
+    // adjust timezone
+    if (!isNaN(this.z) && result.getTimezoneOffset() !== this.z) {
+      result.setUTCFullYear(
+        result.getFullYear(),
+        result.getMonth(),
+        result.getDate())
+
+      result.setUTCHours(
+        result.getHours(),
+        result.getMinutes() + this.z,
+        result.getSeconds(),
+        result.getMilliseconds())
+    }
+
+    return result
+  }
+}
+
+module.exports = function strtotime (str, now) {
+  //       discuss at: http://locutus.io/php/strtotime/
+  //      original by: Caio Ariede (http://caioariede.com)
+  //      improved by: Kevin van Zonneveld (http://kvz.io)
+  //      improved by: Caio Ariede (http://caioariede.com)
+  //      improved by: A. Matías Quezada (http://amatiasq.com)
+  //      improved by: preuter
+  //      improved by: Brett Zamir (http://brett-zamir.me)
+  //      improved by: Mirko Faber
+  //         input by: David
+  //      bugfixed by: Wagner B. Soares
+  //      bugfixed by: Artur Tchernychev
+  //      bugfixed by: Stephan Bösch-Plepelits (http://github.com/plepe)
+  // reimplemented by: Rafał Kukawski
+  //           note 1: Examples all have a fixed timestamp to prevent
+  //           note 1: tests to fail because of variable time(zones)
+  //        example 1: strtotime('+1 day', 1129633200)
+  //        returns 1: 1129719600
+  //        example 2: strtotime('+1 week 2 days 4 hours 2 seconds', 1129633200)
+  //        returns 2: 1130425202
+  //        example 3: strtotime('last month', 1129633200)
+  //        returns 3: 1127041200
+  //        example 4: strtotime('2009-05-04 08:30:00+00')
+  //        returns 4: 1241425800
+  //        example 5: strtotime('2009-05-04 08:30:00+02:00')
+  //        returns 5: 1241418600
+  if (now == null) {
+    now = Math.floor(Date.now() / 1000)
   }
 
-  times = '(years?|months?|weeks?|days?|hours?|minutes?|min|seconds?|sec' +
-    '|sunday|sun\\.?|monday|mon\\.?|tuesday|tue\\.?|wednesday|wed\\.?' +
-    '|thursday|thu\\.?|friday|fri\\.?|saturday|sat\\.?)'
-  regex = '([+-]?\\d+\\s' + times + '|' + '(last|next)\\s' + times + ')(\\sago)?'
+  // the rule order is very fragile
+  // as many formats are similar to others
+  // so small change can cause
+  // input misinterpretation
+  const rules = [
+    formats.yesterday,
+    formats.now,
+    formats.noon,
+    formats.midnightOrToday,
+    formats.tomorrow,
+    formats.timestamp,
+    formats.firstOrLastDay,
+    formats.backOrFrontOf,
+    // formats.weekdayOf, // not yet implemented
+    formats.mssqltime,
+    formats.timeLong12,
+    formats.timeShort12,
+    formats.timeTiny12,
+    formats.soap,
+    formats.wddx,
+    formats.exif,
+    formats.xmlRpc,
+    formats.xmlRpcNoColon,
+    formats.clf,
+    formats.iso8601long,
+    formats.dateTextual,
+    formats.pointedDate4,
+    formats.pointedDate2,
+    formats.timeLong24,
+    formats.dateNoColon,
+    formats.pgydotd,
+    formats.timeShort24,
+    formats.iso8601noColon,
+    // iso8601dateSlash needs to come before dateSlash
+    formats.iso8601dateSlash,
+    formats.dateSlash,
+    formats.american,
+    formats.americanShort,
+    formats.gnuDateShortOrIso8601date2,
+    formats.iso8601date4,
+    formats.gnuNoColon,
+    formats.gnuDateShorter,
+    formats.pgTextReverse,
+    formats.dateFull,
+    formats.dateNoDay,
+    formats.dateNoDayRev,
+    formats.pgTextShort,
+    formats.dateNoYear,
+    formats.dateNoYearRev,
+    formats.isoWeekDay,
+    formats.relativeText,
+    formats.relative,
+    formats.dayText,
+    formats.relativeTextWeek,
+    formats.monthFullOrMonthAbbr,
+    formats.tzCorrection,
+    formats.ago,
+    formats.gnuNoColon2,
+    formats.year4,
+    // note: the two rules below
+    // should always come last
+    formats.whitespace,
+    formats.any
+  ]
 
-  match = text.match(new RegExp(regex, 'gi'))
-  if (!match) {
-    return fail
-  }
+  let result = Object.create(resultProto)
 
-  for (i = 0, len = match.length; i < len; i++) {
-    if (!process(match[i])) {
-      return fail
+  while (str.length) {
+    for (let i = 0, l = rules.length; i < l; i++) {
+      const format = rules[i]
+
+      const match = str.match(format.regex)
+
+      if (match) {
+        // care only about false results. Ignore other values
+        if (format.callback && format.callback.apply(result, match) === false) {
+          return false
+        }
+
+        str = str.substr(match[0].length)
+        break
+      }
     }
   }
 
-  return (date.getTime() / 1000)
+  return Math.floor(result.toDate(new Date(now * 1000)) / 1000)
 }

--- a/src/php/datetime/strtotime.js
+++ b/src/php/datetime/strtotime.js
@@ -180,7 +180,7 @@ const formats = {
   yesterday: {
     regex: /^yesterday/i,
     name: 'yesterday',
-    callback: function () {
+    callback () {
       this.rd -= 1
       return this.resetTime()
     }
@@ -195,7 +195,7 @@ const formats = {
   noon: {
     regex: /^noon/i,
     name: 'noon',
-    callback: function () {
+    callback () {
       return this.resetTime() && this.time(12, 0, 0, 0)
     }
   },
@@ -203,7 +203,7 @@ const formats = {
   midnightOrToday: {
     regex: /^(midnight|today)/i,
     name: 'midnight | today',
-    callback: function () {
+    callback () {
       return this.resetTime()
     }
   },
@@ -211,7 +211,7 @@ const formats = {
   tomorrow: {
     regex: /^tomorrow/i,
     name: 'tomorrow',
-    callback: function () {
+    callback () {
       this.rd += 1
       return this.resetTime()
     }
@@ -220,7 +220,7 @@ const formats = {
   timestamp: {
     regex: /^@(-?\d+)/i,
     name: 'timestamp',
-    callback: function (match, timestamp) {
+    callback (match, timestamp) {
       this.rs += +timestamp
       this.y = 1970
       this.m = 0
@@ -234,7 +234,7 @@ const formats = {
   firstOrLastDay: {
     regex: /^(first|last) day of/i,
     name: 'firstdayof | lastdayof',
-    callback: function (match, day) {
+    callback (match, day) {
       if (day.toLowerCase() === 'first') {
         this.firstOrLastDayOfMonth = 1
       } else {
@@ -246,7 +246,7 @@ const formats = {
   backOrFrontOf: {
     regex: RegExp('^(back|front) of ' + reHour24 + reSpaceOpt + reMeridian + '?', 'i'),
     name: 'backof | frontof',
-    callback: function (match, side, hours, meridian) {
+    callback (match, side, hours, meridian) {
       let back = side.toLowerCase() === 'back'
       let hour = +hours
       let minute = 15
@@ -271,7 +271,7 @@ const formats = {
   mssqltime: {
     regex: RegExp('^' + reHour12 + ':' + reMinutelz + ':' + reSecondlz + '[:.]([0-9]+)' + reMeridian, 'i'),
     name: 'mssqltime',
-    callback: function (match, hour, minute, second, frac, meridian) {
+    callback (match, hour, minute, second, frac, meridian) {
       return this.time(processMeridian(+hour, meridian), +minute, +second, +frac.substr(0, 3))
     }
   },
@@ -279,7 +279,7 @@ const formats = {
   timeLong12: {
     regex: RegExp('^' + reHour12 + '[:.]' + reMinute + '[:.]' + reSecondlz + reSpaceOpt + reMeridian, 'i'),
     name: 'timelong12',
-    callback: function (match, hour, minute, second, meridian) {
+    callback (match, hour, minute, second, meridian) {
       return this.time(processMeridian(+hour, meridian), +minute, +second, 0)
     }
   },
@@ -287,7 +287,7 @@ const formats = {
   timeShort12: {
     regex: RegExp('^' + reHour12 + '[:.]' + reMinutelz + reSpaceOpt + reMeridian, 'i'),
     name: 'timeshort12',
-    callback: function (match, hour, minute, meridian) {
+    callback (match, hour, minute, meridian) {
       return this.time(processMeridian(+hour, meridian), +minute, 0, 0)
     }
   },
@@ -295,7 +295,7 @@ const formats = {
   timeTiny12: {
     regex: RegExp('^' + reHour12 + reSpaceOpt + reMeridian, 'i'),
     name: 'timetiny12',
-    callback: function (match, hour, meridian) {
+    callback (match, hour, meridian) {
       return this.time(processMeridian(+hour, meridian), 0, 0, 0)
     }
   },
@@ -303,7 +303,7 @@ const formats = {
   soap: {
     regex: RegExp('^' + reYear4 + '-' + reMonthlz + '-' + reDaylz + 'T' + reHour24lz + ':' + reMinutelz + ':' + reSecondlz + reFrac + reTzCorrection + '?', 'i'),
     name: 'soap',
-    callback: function (match, year, month, day, hour, minute, second, frac, tzCorrection) {
+    callback (match, year, month, day, hour, minute, second, frac, tzCorrection) {
       return this.ymd(+year, month - 1, +day) &&
               this.time(+hour, +minute, +second, +frac.substr(0, 3)) &&
               this.zone(processTzCorrection(tzCorrection))
@@ -313,7 +313,7 @@ const formats = {
   wddx: {
     regex: RegExp('^' + reYear4 + '-' + reMonth + '-' + reDay + 'T' + reHour24 + ':' + reMinute + ':' + reSecond),
     name: 'wddx',
-    callback: function (match, year, month, day, hour, minute, second) {
+    callback (match, year, month, day, hour, minute, second) {
       return this.ymd(+year, month - 1, +day) && this.time(+hour, +minute, +second, 0)
     }
   },
@@ -321,7 +321,7 @@ const formats = {
   exif: {
     regex: RegExp('^' + reYear4 + ':' + reMonthlz + ':' + reDaylz + ' ' + reHour24lz + ':' + reMinutelz + ':' + reSecondlz, 'i'),
     name: 'exif',
-    callback: function (match, year, month, day, hour, minute, second) {
+    callback (match, year, month, day, hour, minute, second) {
       return this.ymd(+year, month - 1, +day) && this.time(+hour, +minute, +second, 0)
     }
   },
@@ -329,7 +329,7 @@ const formats = {
   xmlRpc: {
     regex: RegExp('^' + reYear4 + reMonthlz + reDaylz + 'T' + reHour24 + ':' + reMinutelz + ':' + reSecondlz),
     name: 'xmlrpc',
-    callback: function (match, year, month, day, hour, minute, second) {
+    callback (match, year, month, day, hour, minute, second) {
       return this.ymd(+year, month - 1, +day) && this.time(+hour, +minute, +second, 0)
     }
   },
@@ -337,7 +337,7 @@ const formats = {
   xmlRpcNoColon: {
     regex: RegExp('^' + reYear4 + reMonthlz + reDaylz + '[Tt]' + reHour24 + reMinutelz + reSecondlz),
     name: 'xmlrpcnocolon',
-    callback: function (match, year, month, day, hour, minute, second) {
+    callback (match, year, month, day, hour, minute, second) {
       return this.ymd(+year, month - 1, +day) && this.time(+hour, +minute, +second, 0)
     }
   },
@@ -345,7 +345,7 @@ const formats = {
   clf: {
     regex: RegExp('^' + reDay + '/(' + reMonthAbbr + ')/' + reYear4 + ':' + reHour24lz + ':' + reMinutelz + ':' + reSecondlz + reSpace + reTzCorrection, 'i'),
     name: 'clf',
-    callback: function (match, day, month, year, hour, minute, second, tzCorrection) {
+    callback (match, day, month, year, hour, minute, second, tzCorrection) {
       return this.ymd(+year, lookupMonth(month), +day) &&
               this.time(+hour, +minute, +second, 0) &&
               this.zone(processTzCorrection(tzCorrection))
@@ -355,7 +355,7 @@ const formats = {
   iso8601long: {
     regex: RegExp('^t?' + reHour24 + '[:.]' + reMinute + '[:.]' + reSecond + reFrac, 'i'),
     name: 'iso8601long',
-    callback: function (match, hour, minute, second, frac) {
+    callback (match, hour, minute, second, frac) {
       return this.time(+hour, +minute, +second, +frac.substr(0, 3))
     }
   },
@@ -363,7 +363,7 @@ const formats = {
   dateTextual: {
     regex: RegExp('^' + reMonthText + '[ .\\t-]*' + reDay + '[,.stndrh\\t ]+' + reYear, 'i'),
     name: 'datetextual',
-    callback: function (match, month, day, year) {
+    callback (match, month, day, year) {
       return this.ymd(processYear(year), lookupMonth(month), +day)
     }
   },
@@ -371,7 +371,7 @@ const formats = {
   pointedDate4: {
     regex: RegExp('^' + reDay + '[.\\t-]' + reMonth + '[.-]' + reYear4),
     name: 'pointeddate4',
-    callback: function (match, day, month, year) {
+    callback (match, day, month, year) {
       return this.ymd(+year, month - 1, +day)
     }
   },
@@ -379,7 +379,7 @@ const formats = {
   pointedDate2: {
     regex: RegExp('^' + reDay + '[.\\t]' + reMonth + '\\.' + reYear2),
     name: 'pointeddate2',
-    callback: function (match, day, month, year) {
+    callback (match, day, month, year) {
       return this.ymd(processYear(year), month - 1, +day)
     }
   },
@@ -387,7 +387,7 @@ const formats = {
   timeLong24: {
     regex: RegExp('^t?' + reHour24 + '[:.]' + reMinute + '[:.]' + reSecond),
     name: 'timelong24',
-    callback: function (match, hour, minute, second) {
+    callback (match, hour, minute, second) {
       return this.time(+hour, +minute, +second, 0)
     }
   },
@@ -395,7 +395,7 @@ const formats = {
   dateNoColon: {
     regex: RegExp('^' + reYear4 + reMonthlz + reDaylz),
     name: 'datenocolon',
-    callback: function (match, year, month, day) {
+    callback (match, year, month, day) {
       return this.ymd(+year, month - 1, +day)
     }
   },
@@ -403,7 +403,7 @@ const formats = {
   pgydotd: {
     regex: RegExp('^' + reYear4 + '\\.?' + reDayOfYear),
     name: 'pgydotd',
-    callback: function (match, year, day) {
+    callback (match, year, day) {
       return this.ymd(+year, 0, +day)
     }
   },
@@ -411,7 +411,7 @@ const formats = {
   timeShort24: {
     regex: RegExp('^t?' + reHour24 + '[:.]' + reMinute, 'i'),
     name: 'timeshort24',
-    callback: function (match, hour, minute) {
+    callback (match, hour, minute) {
       return this.time(+hour, +minute, 0, 0)
     }
   },
@@ -419,7 +419,7 @@ const formats = {
   iso8601noColon: {
     regex: RegExp('^t?' + reHour24lz + reMinutelz + reSecondlz, 'i'),
     name: 'iso8601nocolon',
-    callback: function (match, hour, minute, second) {
+    callback (match, hour, minute, second) {
       return this.time(+hour, +minute, +second, 0)
     }
   },
@@ -430,7 +430,7 @@ const formats = {
     // are handled by dateslash
     regex: RegExp('^' + reYear4 + '/' + reMonthlz + '/' + reDaylz + '/'),
     name: 'iso8601dateslash',
-    callback: function (match, year, month, day) {
+    callback (match, year, month, day) {
       return this.ymd(+year, month - 1, +day)
     }
   },
@@ -438,7 +438,7 @@ const formats = {
   dateSlash: {
     regex: RegExp('^' + reYear4 + '/' + reMonth + '/' + reDay),
     name: 'dateslash',
-    callback: function (match, year, month, day) {
+    callback (match, year, month, day) {
       return this.ymd(+year, month - 1, +day)
     }
   },
@@ -446,7 +446,7 @@ const formats = {
   american: {
     regex: RegExp('^' + reMonth + '/' + reDay + '/' + reYear),
     name: 'american',
-    callback: function (match, month, day, year) {
+    callback (match, month, day, year) {
       return this.ymd(processYear(year), month - 1, +day)
     }
   },
@@ -454,7 +454,7 @@ const formats = {
   americanShort: {
     regex: RegExp('^' + reMonth + '/' + reDay),
     name: 'americanshort',
-    callback: function (match, month, day) {
+    callback (match, month, day) {
       return this.ymd(this.y, month - 1, +day)
     }
   },
@@ -463,7 +463,7 @@ const formats = {
     // iso8601date2 is complete subset of gnudateshort
     regex: RegExp('^' + reYear + '-' + reMonth + '-' + reDay),
     name: 'gnudateshort | iso8601date2',
-    callback: function (match, year, month, day) {
+    callback (match, year, month, day) {
       return this.ymd(processYear(year), month - 1, +day)
     }
   },
@@ -471,7 +471,7 @@ const formats = {
   iso8601date4: {
     regex: RegExp('^' + reYear4withSign + '-' + reMonthlz + '-' + reDaylz),
     name: 'iso8601date4',
-    callback: function (match, year, month, day) {
+    callback (match, year, month, day) {
       return this.ymd(+year, month - 1, +day)
     }
   },
@@ -479,7 +479,7 @@ const formats = {
   gnuNoColon: {
     regex: RegExp('^t' + reHour24lz + reMinutelz, 'i'),
     name: 'gnunocolon',
-    callback: function (match, hour, minute) {
+    callback (match, hour, minute) {
       return this.time(+hour, +minute, 0, this.f)
     }
   },
@@ -487,7 +487,7 @@ const formats = {
   gnuDateShorter: {
     regex: RegExp('^' + reYear4 + '-' + reMonth),
     name: 'gnudateshorter',
-    callback: function (match, year, month) {
+    callback (match, year, month) {
       return this.ymd(+year, month - 1, 1)
     }
   },
@@ -497,7 +497,7 @@ const formats = {
     // years below 32 should be treated as days in datefull
     regex: RegExp('^' + '(\\d{3,4}|[4-9]\\d|3[2-9])-(' + reMonthAbbr + ')-' + reDaylz, 'i'),
     name: 'pgtextreverse',
-    callback: function (match, year, month, day) {
+    callback (match, year, month, day) {
       return this.ymd(processYear(year), lookupMonth(month), +day)
     }
   },
@@ -505,7 +505,7 @@ const formats = {
   dateFull: {
     regex: RegExp('^' + reDay + '[ \\t.-]*' + reMonthText + '[ \\t.-]*' + reYear, 'i'),
     name: 'datefull',
-    callback: function (match, day, month, year) {
+    callback (match, day, month, year) {
       return this.ymd(processYear(year), lookupMonth(month), +day)
     }
   },
@@ -513,7 +513,7 @@ const formats = {
   dateNoDay: {
     regex: RegExp('^' + reMonthText + '[ .\\t-]*' + reYear4, 'i'),
     name: 'datenoday',
-    callback: function (match, month, year) {
+    callback (match, month, year) {
       return this.ymd(+year, lookupMonth(month), 1)
     }
   },
@@ -521,7 +521,7 @@ const formats = {
   dateNoDayRev: {
     regex: RegExp('^' + reYear4 + '[ .\\t-]*' + reMonthText, 'i'),
     name: 'datenodayrev',
-    callback: function (match, year, month) {
+    callback (match, year, month) {
       return this.ymd(+year, lookupMonth(month), 1)
     }
   },
@@ -529,7 +529,7 @@ const formats = {
   pgTextShort: {
     regex: RegExp('^(' + reMonthAbbr + ')-' + reDaylz + '-' + reYear, 'i'),
     name: 'pgtextshort',
-    callback: function (match, month, day, year) {
+    callback (match, month, day, year) {
       return this.ymd(processYear(year), lookupMonth(month), +day)
     }
   },
@@ -537,7 +537,7 @@ const formats = {
   dateNoYear: {
     regex: RegExp('^' + reMonthText + '[ .\\t-]*' + reDay + '[,.stndrh\\t ]*', 'i'),
     name: 'datenoyear',
-    callback: function (match, month, day) {
+    callback (match, month, day) {
       return this.ymd(this.y, lookupMonth(month), +day)
     }
   },
@@ -545,7 +545,7 @@ const formats = {
   dateNoYearRev: {
     regex: RegExp('^' + reDay + '[ .\\t-]*' + reMonthText, 'i'),
     name: 'datenoyearrev',
-    callback: function (match, day, month) {
+    callback (match, day, month) {
       return this.ymd(this.y, lookupMonth(month), +day)
     }
   },
@@ -553,7 +553,7 @@ const formats = {
   isoWeekDay: {
     regex: RegExp('^' + reYear4 + '-?W' + reWeekOfYear + '(?:-?([0-7]))?'),
     name: 'isoweekday | isoweek',
-    callback: function (match, year, week, day) {
+    callback (match, year, week, day) {
       day = day ? +day : 1
 
       if (!this.ymd(+year, 0, 1)) {
@@ -573,7 +573,7 @@ const formats = {
   relativeText: {
     regex: RegExp('^(' + reReltextnumber + '|' + reReltexttext + ')' + reSpace + '(' + reReltextunit + ')', 'i'),
     name: 'relativetext',
-    callback: function (match, relValue, relUnit) {
+    callback (match, relValue, relUnit) {
       // todo: implement handling of 'this time-unit'
       // eslint-disable-next-line no-unused-vars
       const { amount, behavior } = lookupRelative(relValue)
@@ -640,7 +640,7 @@ const formats = {
   relative: {
     regex: RegExp('^([+-]*)[ \\t]*(\\d+)' + reSpaceOpt + '(' + reReltextunit + '|week)', 'i'),
     name: 'relative',
-    callback: function (match, signs, relValue, relUnit) {
+    callback (match, signs, relValue, relUnit) {
       const minuses = signs.replace(/[^-]/g, '').length
 
       let amount = +relValue * Math.pow(-1, minuses)
@@ -707,7 +707,7 @@ const formats = {
   dayText: {
     regex: RegExp('^(' + reDaytext + ')', 'i'),
     name: 'daytext',
-    callback: function (match, dayText) {
+    callback (match, dayText) {
       this.resetTime()
       this.weekday = lookupWeekday(dayText, 0)
 
@@ -720,7 +720,7 @@ const formats = {
   relativeTextWeek: {
     regex: RegExp('^(' + reReltexttext + ')' + reSpace + 'week', 'i'),
     name: 'relativetextweek',
-    callback: function (match, relText) {
+    callback (match, relText) {
       this.weekdayBehavior = 2
 
       switch (relText.toLowerCase()) {
@@ -745,7 +745,7 @@ const formats = {
   monthFullOrMonthAbbr: {
     regex: RegExp('^(' + reMonthFull + '|' + reMonthAbbr + ')', 'i'),
     name: 'monthfull | monthabbr',
-    callback: function (match, month) {
+    callback (match, month) {
       return this.ymd(this.y, lookupMonth(month), this.d)
     }
   },
@@ -753,7 +753,7 @@ const formats = {
   tzCorrection: {
     regex: RegExp('^' + reTzCorrection, 'i'),
     name: 'tzcorrection',
-    callback: function (tzCorrection) {
+    callback (tzCorrection) {
       return this.zone(processTzCorrection(tzCorrection))
     }
   },
@@ -761,7 +761,7 @@ const formats = {
   ago: {
     regex: /^ago/i,
     name: 'ago',
-    callback: function () {
+    callback () {
       this.ry = -this.ry
       this.rm = -this.rm
       this.rd = -this.rd
@@ -779,7 +779,7 @@ const formats = {
     // only year4 should come afterwards
     regex: RegExp('^' + reHour24lz + reMinutelz, 'i'),
     name: 'gnunocolon',
-    callback: function (match, hour, minute) {
+    callback (match, hour, minute) {
       return this.time(+hour, +minute, 0, this.f)
     }
   },
@@ -787,7 +787,7 @@ const formats = {
   year4: {
     regex: RegExp('^' + reYear4),
     name: 'year4',
-    callback: function (match, year) {
+    callback (match, year) {
       this.y = +year
       return true
     }
@@ -802,7 +802,7 @@ const formats = {
   any: {
     regex: /^[\s\S]+/,
     name: 'any',
-    callback: function () {
+    callback () {
       return false
     }
   }
@@ -845,7 +845,7 @@ let resultProto = {
   zones: 0,
 
   // helper functions
-  ymd: function (y, m, d) {
+  ymd (y, m, d) {
     if (this.dates > 0) {
       return false
     }
@@ -857,7 +857,7 @@ let resultProto = {
     return true
   },
 
-  time: function (h, i, s, f) {
+  time (h, i, s, f) {
     if (this.times > 0) {
       return false
     }
@@ -871,7 +871,7 @@ let resultProto = {
     return true
   },
 
-  resetTime: function () {
+  resetTime () {
     this.h = 0
     this.i = 0
     this.s = 0
@@ -881,7 +881,7 @@ let resultProto = {
     return true
   },
 
-  zone: function (minutes) {
+  zone (minutes) {
     if (this.zones <= 1) {
       this.zones++
       this.z = minutes
@@ -891,7 +891,7 @@ let resultProto = {
     return false
   },
 
-  toDate: function (relativeTo) {
+  toDate (relativeTo) {
     if (this.dates && !this.times) {
       this.h = this.i = this.s = this.f = 0
     }


### PR DESCRIPTION
THIS IS A BREAKING CHANGE, some old behavior, which relied on JS-engine built-in date parsing, is removed.
This patch re-implements strtotime based on PHP's source code. It is not 100% complete.
Missing are:
- weekdayof
- this time-unit, eg. this week
- time zone handling (e.g. Europe/Berlin, GMT, Z), but time-zone corrections (+01:00) work

