### PR TITLE
Fix code listing on locutus website

### DIFF
--- a/src/_util/util.js
+++ b/src/_util/util.js
@@ -634,7 +634,7 @@ class Util {
       name: name,
       filepath: filepath,
       codepath: codepath,
-      // code: code,
+      code: code,
       language: language,
       category: category,
       func_name: funcName,


### PR DESCRIPTION
When reimplementing utils to use esprima, a line that was needed for displaying code on locutus website was accidentally commented out.