### PR TITLE
Fix issues with incorrect values being returned

### DIFF
--- a/src/php/var/is_callable.js
+++ b/src/php/var/is_callable.js
@@ -3,6 +3,7 @@ module.exports = function is_callable (mixedVar, syntaxOnly, callableName) { // 
   // original by: Brett Zamir (http://brett-zamir.me)
   //    input by: François
   // improved by: Brett Zamir (http://brett-zamir.me)
+  // improved by: KnightYoshi
   //      note 1: The variable callableName cannot work as a string variable passed by
   //      note 1: reference as in PHP (since JavaScript does not support passing
   //      note 1: strings by reference), but instead will take the name of
@@ -25,6 +26,8 @@ module.exports = function is_callable (mixedVar, syntaxOnly, callableName) { // 
   //   returns 3: 'SomeClass::someMethod'
   //   example 4: is_callable(function () {})
   //   returns 4: true
+  //   example 5: is_callable(class MyClass {})
+  //   returns 5: false
 
   var $global = (typeof window !== 'undefined' ? window : global)
 

--- a/src/php/var/is_callable.js
+++ b/src/php/var/is_callable.js
@@ -43,6 +43,10 @@ module.exports = function is_callable (mixedVar, syntaxOnly, callableName) { // 
     return name[1]
   }
 
+  if(/^class/.test(mixedVar.toString())) {
+	  return false;
+  }
+
   if (typeof mixedVar === 'string') {
     obj = $global
     method = mixedVar
@@ -57,8 +61,6 @@ module.exports = function is_callable (mixedVar, syntaxOnly, callableName) { // 
     obj = mixedVar[0]
     method = mixedVar[1]
     name = (obj.constructor && getFuncName(obj.constructor)) + '::' + method
-  } else {
-    return false
   }
 
   if (syntaxOnly || typeof obj[method] === 'function') {

--- a/website/source/php/var/is_callable.html
+++ b/website/source/php/var/is_callable.html
@@ -10,18 +10,21 @@ examples:
     is_callable([testObj, 'someMethod'], true, 'myVar')
     var $result = myVar
   - 'is_callable(function () {})'
+  - 'is_callable(class MyClass {})'
 estarget: es5
 returns:
   - 'true'
   - true // gives true because does not do strict checking
   - '''SomeClass::someMethod'''
   - 'true'
+  - 'false'
 dependencies: []
 authors:
   original by:
     - 'Brett Zamir (http://brett-zamir.me)'
   improved by:
     - 'Brett Zamir (http://brett-zamir.me)'
+    - KnightYoshi
   input by:
     - François
 notes:
@@ -59,6 +62,7 @@ alias:
   // original by: Brett Zamir (http://brett-zamir.me)
   //    input by: François
   // improved by: Brett Zamir (http://brett-zamir.me)
+  // improved by: KnightYoshi
   //      note 1: The variable callableName cannot work as a string variable passed by
   //      note 1: reference as in PHP (since JavaScript does not support passing
   //      note 1: strings by reference), but instead will take the name of
@@ -81,6 +85,8 @@ alias:
   //   returns 3: 'SomeClass::someMethod'
   //   example 4: is_callable(function () {})
   //   returns 4: true
+  //   example 5: is_callable(class MyClass {})
+  //   returns 5: false
 
   var $global = (typeof window !== 'undefined' ? window : global)
 
@@ -99,6 +105,10 @@ alias:
     return name[1]
   }
 
+  if(/^class/.test(mixedVar.toString())) {
+	  return false;
+  }
+
   if (typeof mixedVar === 'string') {
     obj = $global
     method = mixedVar
@@ -113,8 +123,6 @@ alias:
     obj = mixedVar[0]
     method = mixedVar[1]
     name = (obj.constructor && getFuncName(obj.constructor)) + '::' + method
-  } else {
-    return false
   }
 
   if (syntaxOnly || typeof obj[method] === 'function') {


### PR DESCRIPTION
### Description
Fixed an issue with an else statement that always returned false if the conditions failed and it would get to the other checks. 

Add check if the variable passed is an ES6 class because ES6 classes cannot be called, but they were returning true