### PR TITLE
Fix handling of associative arrays in PHP's var_export

### DIFF
--- a/src/php/var/var_export.js
+++ b/src/php/var/var_export.js
@@ -14,6 +14,8 @@ module.exports = function var_export (mixedExpression, boolReturn) { // eslint-d
   //   example 3: var data = 'Kevin'
   //   example 3: var_export(data, true)
   //   returns 3: "'Kevin'"
+  //   example 4: var_export({0: 'Kevin', 1: 'van', 'lastName': 'Zonneveld'}, true)
+  //   returns 4: "array (\n  0 => 'Kevin',\n  1 => 'van',\n  'lastName' => 'Zonneveld'\n)"
 
   var echo = require('../strings/echo')
   var retstr = ''
@@ -34,6 +36,11 @@ module.exports = function var_export (mixedExpression, boolReturn) { // eslint-d
       return '(Anonymous)'
     }
     return name[1]
+  }
+  
+  var _isNormalInteger = function (string) {
+    var number = Math.floor(Number(string));
+    return number !== Infinity && String(number) === string && number >= 0;
   }
 
   var _makeIndent = function (idtLevel) {
@@ -87,6 +94,7 @@ module.exports = function var_export (mixedExpression, boolReturn) { // eslint-d
       value = var_export(mixedExpression[i], 1, idtLevel + 2)
       value = typeof value === 'string' ? value.replace(/</g, '&lt;')
         .replace(/>/g, '&gt;') : value
+      i = _isNormalInteger(i) ? i : `'${i}'`
       x[cnt++] = innerIndent + i + ' => ' +
         (__getType(mixedExpression[i]) === 'array' ? '\n' : '') + value
     }

--- a/src/php/var/var_export.js
+++ b/src/php/var/var_export.js
@@ -7,6 +7,7 @@ module.exports = function var_export (mixedExpression, boolReturn) { // eslint-d
   //    input by: Hans Henrik (https://hanshenrik.tk/)
   // bugfixed by: Brett Zamir (https://brett-zamir.me)
   // bugfixed by: Brett Zamir (https://brett-zamir.me)
+  // bugfixed by: simivar (https://github.com/simivar)
   //   example 1: var_export(null)
   //   returns 1: null
   //   example 2: var_export({0: 'Kevin', 1: 'van', 2: 'Zonneveld'}, true)
@@ -37,10 +38,10 @@ module.exports = function var_export (mixedExpression, boolReturn) { // eslint-d
     }
     return name[1]
   }
-  
+
   var _isNormalInteger = function (string) {
-    var number = Math.floor(Number(string));
-    return number !== Infinity && String(number) === string && number >= 0;
+    var number = Math.floor(Number(string))
+    return number !== Infinity && String(number) === string && number >= 0
   }
 
   var _makeIndent = function (idtLevel) {


### PR DESCRIPTION
In PHP when you use `var_export` on associative array all string keys are inside single quotes. Currently all keys in this function are returned without single quotes around them. This commit fixes this issue.

Example of PHP's behaviour:
```
$array = [
    'username' => 'simivar',
];
```

it produces string with key in single quotes like:

```
array(
  'username' => 'simivar'
)
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/kvz/locutus/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/kvz/locutus/pulls) for the same update/change?

### Description
