### PR TITLE
Fix arrows of nested arrays in PHP's var_export

### DIFF
--- a/src/php/var/var_export.js
+++ b/src/php/var/var_export.js
@@ -96,8 +96,6 @@ module.exports = function var_export (mixedExpression, boolReturn) { // eslint-d
     innerIndent = _makeIndent(idtLevel)
     for (i in mixedExpression) {
       value = var_export(mixedExpression[i], 1, idtLevel + 2)
-      value = typeof value === 'string' ? value.replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;') : value
       i = _isNormalInteger(i) ? i : `'${i}'`
       x[cnt++] = innerIndent + i + ' => ' +
         (__getType(mixedExpression[i]) === 'array' ? '\n' : '') + value


### PR DESCRIPTION
Currently for every nested value `var_export` is replacing all less-than signs and greater-tan signs with their respective HTML entities. This happens because `typeof value` is always `string` when it comes to result of recursive call to `var_export` function. This introduces problem with nested arrays where `=>` gets replaced with `>&gt;`.

For example currently `var_export({ test: [ 'a', 'b' ] })` produces:
```
array (
  'test' =>   array (
    0 =&gt; 'a',
    1 =&gt; 'b'
  )
)
```

instead of
```
array (
  'test' =>   array (
    0 => 'a',
    1 => 'b'
  )
)
```

I could not find an example where this specific replace should take place. PHP does not do that on any strings that I could think of that's why I deleted this line altogether.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/kvz/locutus/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/kvz/locutus/pulls) for the same update/change?

### Description
