### PR TITLE
Fix indent of nested arrays in PHP's var_export

### DIFF
--- a/src/php/var/var_export.js
+++ b/src/php/var/var_export.js
@@ -100,7 +100,7 @@ module.exports = function var_export (mixedExpression, boolReturn) { // eslint-d
     for (i in mixedExpression) {
       value = ''
       if (__getType(mixedExpression[i]) === 'array') {
-          value = '\n'
+        value = '\n'
       }
       value += var_export(mixedExpression[i], 1, idtLevel + 2)
       value = typeof value === 'string' ? value.replace(/</g, '&lt;')

--- a/src/php/var/var_export.js
+++ b/src/php/var/var_export.js
@@ -99,7 +99,8 @@ module.exports = function var_export (mixedExpression, boolReturn) { // eslint-d
     innerIndent = _makeIndent(idtLevel)
     for (i in mixedExpression) {
       value = ''
-      if (__getType(mixedExpression[i]) === 'array') {
+      var subtype = __getType(mixedExpression[i])
+      if (subtype === 'array' || subtype === 'object') {
         value = '\n'
       }
       value += var_export(mixedExpression[i], 1, idtLevel + 2)

--- a/src/php/var/var_export.js
+++ b/src/php/var/var_export.js
@@ -103,7 +103,7 @@ module.exports = function var_export (mixedExpression, boolReturn) { // eslint-d
       if (subtype === 'array' || subtype === 'object') {
         value = '\n'
       }
-      value = var_export(mixedExpression[i], 1, idtLevel + 2)
+      value += var_export(mixedExpression[i], 1, idtLevel + 2)
       i = _isNormalInteger(i) ? i : `'${i}'`
       x[cnt++] = innerIndent + i + ' => ' + value
     }

--- a/src/php/var/var_export.js
+++ b/src/php/var/var_export.js
@@ -9,6 +9,7 @@ module.exports = function var_export (mixedExpression, boolReturn) { // eslint-d
   // bugfixed by: Brett Zamir (https://brett-zamir.me)
   // bugfixed by: simivar (https://github.com/simivar)
   // bugfixed by: simivar (https://github.com/simivar)
+  // bugfixed by: simivar (https://github.com/simivar)
   //   example 1: var_export(null)
   //   returns 1: null
   //   example 2: var_export({0: 'Kevin', 1: 'van', 2: 'Zonneveld'}, true)
@@ -20,6 +21,8 @@ module.exports = function var_export (mixedExpression, boolReturn) { // eslint-d
   //   returns 4: "array (\n  0 => 'Kevin',\n  1 => 'van',\n  'lastName' => 'Zonneveld'\n)"
   //   example 5: var_export([], true)
   //   returns 5: "array (\n)"
+  //   example 6: var_export({ test: [ 'a', 'b' ] }, true)
+  //   returns 6: "array (\n  'test' =>\n  array (\n    0 => 'a',\n    1 => 'b'\n  )\n)"
 
   var echo = require('../strings/echo')
   var retstr = ''
@@ -95,12 +98,15 @@ module.exports = function var_export (mixedExpression, boolReturn) { // eslint-d
     outerIndent = _makeIndent(idtLevel - 2)
     innerIndent = _makeIndent(idtLevel)
     for (i in mixedExpression) {
-      value = var_export(mixedExpression[i], 1, idtLevel + 2)
+      value = ''
+      if (__getType(mixedExpression[i]) === 'array') {
+          value = '\n'
+      }
+      value += var_export(mixedExpression[i], 1, idtLevel + 2)
       value = typeof value === 'string' ? value.replace(/</g, '&lt;')
         .replace(/>/g, '&gt;') : value
       i = _isNormalInteger(i) ? i : `'${i}'`
-      x[cnt++] = innerIndent + i + ' => ' +
-        (__getType(mixedExpression[i]) === 'array' ? '\n' : '') + value
+      x[cnt++] = innerIndent + i + ' => ' + value
     }
     if (x.length > 0) {
       iret = x.join(',\n') + '\n'

--- a/src/php/var/var_export.js
+++ b/src/php/var/var_export.js
@@ -98,14 +98,14 @@ module.exports = function var_export (mixedExpression, boolReturn) { // eslint-d
     outerIndent = _makeIndent(idtLevel - 2)
     innerIndent = _makeIndent(idtLevel)
     for (i in mixedExpression) {
-      value = ''
+      value = ' '
       var subtype = __getType(mixedExpression[i])
       if (subtype === 'array' || subtype === 'object') {
         value = '\n'
       }
       value += var_export(mixedExpression[i], 1, idtLevel + 2)
       i = _isNormalInteger(i) ? i : `'${i}'`
-      x[cnt++] = innerIndent + i + ' => ' + value
+      x[cnt++] = innerIndent + i + ' =>' + value
     }
     if (x.length > 0) {
       iret = x.join(',\n') + '\n'


### PR DESCRIPTION
Currently for every nested array `var_export` is keeping `array(` string on the same line with indent as key name when in fact it should be in new line.

For example currently `var_export({ test: [ 'a', 'b' ] })` produces:
```
array (
  'test' =>   array (
    0 =&gt; 'a',
    1 =&gt; 'b'
  )
)
```

instead of
```
array (
  'test' =>
  array (
    0 => 'a',
    1 => 'b'
  )
)
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/kvz/locutus/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/kvz/locutus/pulls) for the same update/change?

### Description
