### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/src/php/strings/parse_str.js
+++ b/src/php/strings/parse_str.js
@@ -74,6 +74,10 @@ module.exports = function parse_str (str, array) { // eslint-disable-line camelc
     key = _fixStr(tmp[0])
     value = (tmp.length < 2) ? '' : _fixStr(tmp[1])
 
+    if (key.includes('__proto__') || key.includes('constructor') || key.includes('prototype')) {
+      break;
+    }
+
     while (key.charAt(0) === ' ') {
       key = key.slice(1)
     }


### PR DESCRIPTION
https://huntr.dev/users/Asjidkalam has fixed the Prototype Pollution vulnerability 🔨. Asjidkalam has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?
           
Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/locutus/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/locutus/1/README.md

### User Comments:

### 📊 Metadata *

Prototype Pollution bug

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-locutus

### ⚙️ Description *

phpjs is a community built PHP binding in JavaScript. This package is vulnerable to Prototype Pollution via `parse_str`.
_(Changed to `locutus` - https://github.com/kvz/locutus)_

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

### 💻 Technical Description *

The bug is fixed by validating the input `strArray` to check for prototypes. It is implemented by a simple validation to check for prototype keywords `(__proto__, constructor and prototype)`, where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability. 

### 🐛 Proof of Concept (PoC) *

Clone the project, install the required dependencies and on running the below snippet of code, it triggers prototype pollution and logs `true`.
```javascript
const phpjs = require('phpjs');
phpjs.parse_str("__proto__[polluted]=true",{}); 
console.log(polluted);
```

![before](https://user-images.githubusercontent.com/16708391/91190168-ed99e400-e710-11ea-8280-a206a66c0ca2.JPG)


### 🔥 Proof of Fix (PoF) *

After the fix is applied, it returns an error since the polluted referred in the PoC is no more accessible(which is intended). Hence fixing the issue.

![after](https://user-images.githubusercontent.com/16708391/91190355-1e7a1900-e711-11ea-9e80-ded33938ac6a.JPG)


### 👍 User Acceptance Testing (UAT)

Just prevented some keywords as `key` and no breaking changes are introduced. :)
